### PR TITLE
ModuleFileHandler bug fixes + ComposedLookItemModelHandler bug fixes + ComposedLookItem syntax

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/ComposedLookItemModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/ComposedLookItemModelHandler.cs
@@ -19,16 +19,14 @@ namespace SPMeta2.CSOM.ModelHandlers
             base.MapListItemProperties(newItem, listItemModel);
 
             var definition = listItemModel.WithAssertAndCast<ComposedLookItemDefinition>("model", value => value.RequireNotNull());
-
-            // composed look
-            // 0x00EBB0D5D32C733345B0AA3C79625DD501
-            newItem[BuiltInInternalFieldNames.ContentTypeId] = "0x00EBB0D5D32C733345B0AA3C79625DD501";
+            
+            newItem[BuiltInInternalFieldNames.ContentTypeId] = BuiltInContentTypeId.ComposedLook;
             newItem["Name"] = definition.Name;
 
             SetUrlFieldValue(newItem, "MasterPageUrl", definition.MasterPageUrl, definition.MasterPageDescription);
-            SetUrlFieldValue(newItem, "ThemeUrl", definition.MasterPageUrl, definition.MasterPageDescription);
-            SetUrlFieldValue(newItem, "ImageUrl", definition.MasterPageUrl, definition.MasterPageDescription);
-            SetUrlFieldValue(newItem, "FontSchemeUrl", definition.MasterPageUrl, definition.MasterPageDescription);
+            SetUrlFieldValue(newItem, "ThemeUrl", definition.ThemeUrl, definition.ThemeDescription);
+            SetUrlFieldValue(newItem, "ImageUrl", definition.ImageUrl, definition.ImageDescription);
+            SetUrlFieldValue(newItem, "FontSchemeUrl", definition.FontSchemeDescription, definition.MasterPageDescription);
 
             if (definition.DisplayOrder.HasValue)
                 newItem["DisplayOrder"] = definition.DisplayOrder.Value;

--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/ModuleFileModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/ModuleFileModelHandler.cs
@@ -298,11 +298,16 @@ namespace SPMeta2.CSOM.ModelHandlers
         {
             var context = folderHost.CurrentLibraryFolder.Context;
             var list = folderHost.CurrentList;
-
             var stringCustomContentType = string.Empty;
-            // preload custm content type
-            if (!string.IsNullOrEmpty(moduleFile.ContentTypeName))
+
+            if (!string.IsNullOrEmpty(moduleFile.ContentTypeId))
             {
+                stringCustomContentType = moduleFile.ContentTypeId;
+            }
+            else if (!string.IsNullOrEmpty(moduleFile.ContentTypeName))
+            {
+                // preload custom content type
+
                 var listContentTypes = list.ContentTypes;
                 context.Load(listContentTypes);
                 context.ExecuteQueryWithTrace();

--- a/SPMeta2/SPMeta2.Syntax.Default/ComposedLookItemDefinitionSyntax.cs
+++ b/SPMeta2/SPMeta2.Syntax.Default/ComposedLookItemDefinitionSyntax.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using SPMeta2.Definitions;
+using SPMeta2.Models;
+using SPMeta2.Syntax.Default.Extensions;
+
+namespace SPMeta2.Syntax.Default
+{
+    public static class ComposedLookItemDefinitionSyntax
+    {
+        #region methods
+
+        public static ModelNode AddComposedLookItem(this ModelNode model, ComposedLookItemDefinition definition)
+        {
+            return AddComposedLookItem(model, definition, null);
+        }
+
+        public static ModelNode AddComposedLookItem(this ModelNode model, ComposedLookItemDefinition definition, Action<ModelNode> action)
+        {
+            return model.AddDefinitionNode(definition, action);
+        }
+
+        #endregion
+    }
+}

--- a/SPMeta2/SPMeta2.Syntax.Default/SPMeta2.Syntax.Default.csproj
+++ b/SPMeta2/SPMeta2.Syntax.Default/SPMeta2.Syntax.Default.csproj
@@ -103,6 +103,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ComposedLookItemDefinitionSyntax.cs" />
     <Compile Include="DependentLookupFieldDefinitionSyntax.cs" />
     <Compile Include="DeleteWebPartsDefinitionSyntax.cs" />
     <Compile Include="ChoiceFieldDefinitionSyntax.cs" />

--- a/SPMeta2/SPMeta2/Definitions/ComposedLookItemDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/ComposedLookItemDefinition.cs
@@ -54,7 +54,7 @@ namespace SPMeta2.Definitions
         [DataMember]
         [ExpectUpdate]
         [ExpectNullable]
-        public string ThemePageDescription { get; set; }
+        public string ThemeDescription { get; set; }
 
         [ExpectValidation]
         [DataMember]

--- a/SPMeta2/SPMeta2/Enumerations/BuiltInContentTypeNames.cs
+++ b/SPMeta2/SPMeta2/Enumerations/BuiltInContentTypeNames.cs
@@ -71,5 +71,7 @@ namespace SPMeta2.Enumerations
 
         public static readonly string XMLDocument = "0x010101";
         public static readonly string XSLStyle = "0x010100734778F2B7DF462491FC91844AE431CF";
+
+        public static readonly string ComposedLook = "0x00EBB0D5D32C733345B0AA3C79625DD501";
     }
 }


### PR DESCRIPTION
Bug fix: ModuleFileHandler never used ContentTypeId. Not it uses if
specified.