### PR TITLE
Fixed bug in RemoveStartingSlash

### DIFF
--- a/SPMeta2/SPMeta2/Utils/UrlUtility.cs
+++ b/SPMeta2/SPMeta2/Utils/UrlUtility.cs
@@ -13,10 +13,10 @@ namespace SPMeta2.Utils
             var result = url;
 
             while (result.StartsWith("/"))
-                result = result.Remove(0);
+                result = result.Remove(0, 1);
 
             if (result.StartsWith(@"\"))
-                result = result.Remove(0);
+                result = result.Remove(0, 1);
 
             return result;
         }


### PR DESCRIPTION
RemoveStartingSlash uses String.Remove(0) to remove first symbol from
string. It actually removes whole string. It has to be String.Remove(0,
1) instead. It actually removes first symbol.

This affects WelcomePageModelHandler.