### PR TITLE
Added WebDefinition.IndexedPropertyKeys

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/WebModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/WebModelHandler.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Diagnostics;
-using System.Runtime.Remoting.Contexts;
+using System.Text;
 using Microsoft.SharePoint.Client;
+
 using SPMeta2.Common;
 using SPMeta2.CSOM.Extensions;
 using SPMeta2.CSOM.ModelHosts;
 using SPMeta2.Definitions;
-using SPMeta2.ModelHandlers;
 using SPMeta2.ModelHosts;
 using SPMeta2.Utils;
 using SPMeta2.Exceptions;
@@ -117,7 +116,7 @@ namespace SPMeta2.CSOM.ModelHandlers
             context.ExecuteQueryWithTrace();
         }
 
-        private Site ExtractHostSite(object modelHost)
+        private static Site ExtractHostSite(object modelHost)
         {
             if (modelHost is SiteModelHost)
                 return (modelHost as SiteModelHost).HostSite;
@@ -141,7 +140,7 @@ namespace SPMeta2.CSOM.ModelHandlers
 
         private static Web GetParentWeb(WebModelHost csomModelHost)
         {
-            Web parentWeb = null;
+            Web parentWeb;
 
             if (csomModelHost.HostWeb != null)
                 parentWeb = csomModelHost.HostWeb;
@@ -165,7 +164,7 @@ namespace SPMeta2.CSOM.ModelHandlers
 
             var context = parentWeb.Context;
 
-            Web web = null;
+            Web web;
 
             var scope = new ExceptionHandlingScope(context);
 
@@ -368,10 +367,7 @@ namespace SPMeta2.CSOM.ModelHandlers
             web.Title = webModel.Title;
             web.Description = webModel.Description ?? string.Empty;
 
-            var supportedRuntime = ReflectionUtils.HasProperty(web, "AlternateCssUrl")
-                                 && ReflectionUtils.HasProperty(web, "SiteLogoUrl");
-
-
+            var supportedRuntime = ReflectionUtils.HasProperty(web, "AlternateCssUrl") && ReflectionUtils.HasProperty(web, "SiteLogoUrl");
             if (supportedRuntime)
             {
                 var context = web.Context;
@@ -396,6 +392,16 @@ namespace SPMeta2.CSOM.ModelHandlers
             {
                 TraceService.Critical((int)LogEventId.ModelProvisionCoreCall,
                     "CSOM runtime doesn't have Web.AlternateCssUrl and Web.SiteLogoUrl methods support. Update CSOM runtime to a new version. Provision is skipped");
+            }
+
+            if (webModel.IndexedPropertyKeys.Any())
+            {
+                var props = web.AllProperties;
+                // TODO Not sure if property name should be hardcoded in here and if web.Update needs to be called here
+                props["vti_indexedpropertykeys"] = GetEncodedValueForSearchIndexProperty(webModel.IndexedPropertyKeys);
+
+                web.Update();
+                web.Context.ExecuteQueryWithTrace();
             }
         }
 
@@ -443,6 +449,23 @@ namespace SPMeta2.CSOM.ModelHandlers
                 { "TitleResource", definition.TitleResource },
                 { "DescriptionResource", definition.DescriptionResource },
             });
+        }
+
+        /// <summary>
+        /// Method to create property bag for search index properties
+        /// http://blogs.msdn.com/b/vesku/archive/2013/10/12/ftc-to-cam-setting-indexed-property-bag-keys-using-csom.aspx
+        /// </summary>
+        /// <param name="keys"></param>
+        /// <returns></returns>
+        public static string GetEncodedValueForSearchIndexProperty(IEnumerable<string> keys)
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (var current in keys)
+            {
+                stringBuilder.Append(Convert.ToBase64String(Encoding.Unicode.GetBytes(current)));
+                stringBuilder.Append('|');
+            }
+            return stringBuilder.ToString();
         }
 
         #endregion

--- a/SPMeta2/SPMeta2.Regression.SSOM/Validation/WebDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.SSOM/Validation/WebDefinitionValidator.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq;
+
 using Microsoft.SharePoint;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using SPMeta2.Containers.Assertion;
 using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
 using SPMeta2.Regression.SSOM.Extensions;
 using SPMeta2.SSOM.ModelHandlers;
 using SPMeta2.SSOM.ModelHosts;
 using SPMeta2.Utils;
-
 
 namespace SPMeta2.Regression.SSOM.Validation
 {
@@ -87,8 +84,7 @@ namespace SPMeta2.Regression.SSOM.Validation
                 };
             });
 
-
-            /// localization
+            // localization
             if (definition.TitleResource.Any())
             {
                 assert.ShouldBeEqual((p, s, d) =>
@@ -152,7 +148,29 @@ namespace SPMeta2.Regression.SSOM.Validation
             {
                 assert.SkipProperty(m => m.DescriptionResource, "DescriptionResource is NULL or empty. Skipping.");
             }
+
+            if (definition.IndexedPropertyKeys.Any())
+            {
+                assert.ShouldBeEqual((p, s, d) =>
+                {
+                    var srcProp = s.GetExpressionValue(def => def.IndexedPropertyKeys);
+                    
+                    // Search if any indexPropertyKey from definition is not in WebModel
+                    var differentKeys = s.IndexedPropertyKeys.Except(d.IndexedPropertyKeys);
+
+                    var isValid = !differentKeys.Any();
+                    
+                    return new PropertyValidationResult
+                    {
+                        Tag = p.Tag,
+                        Src = srcProp,
+                        Dst = null,
+                        IsValid = isValid
+                    };
+                });
+            }
+            else
+                assert.SkipProperty(m => m.IndexedPropertyKeys, "IndexedPropertyKeys is NULL or empty. Skipping.");
         }
     }
-
 }

--- a/SPMeta2/SPMeta2.SSOM/ModelHandlers/WebModelHandler.cs
+++ b/SPMeta2/SPMeta2.SSOM/ModelHandlers/WebModelHandler.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+
 using Microsoft.SharePoint;
 using Microsoft.SharePoint.Utilities;
+
 using SPMeta2.Common;
 using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
-using SPMeta2.ModelHandlers;
 using SPMeta2.Services;
 using SPMeta2.SSOM.ModelHosts;
 using SPMeta2.Utils;
@@ -30,11 +30,11 @@ namespace SPMeta2.SSOM.ModelHandlers
 
             if (modelHost is SiteModelHost)
             {
-                CreateWeb(modelHost, (modelHost as SiteModelHost).HostSite.RootWeb, webModel);
+                CreateWeb(modelHost, ((SiteModelHost) modelHost).HostSite.RootWeb, webModel);
             }
             else if (parentHost is WebModelHost)
             {
-                CreateWeb(modelHost, (parentHost as WebModelHost).HostWeb, webModel);
+                CreateWeb(modelHost, ((WebModelHost) parentHost).HostWeb, webModel);
             }
             else
             {
@@ -66,7 +66,7 @@ namespace SPMeta2.SSOM.ModelHandlers
         private static void MapProperties(SPWeb web, WebDefinition webModel)
         {
             web.Title = webModel.Title;
-            web.Description = string.IsNullOrEmpty(webModel.Description) ? String.Empty : webModel.Description;
+            web.Description = string.IsNullOrEmpty(webModel.Description) ? string.Empty : webModel.Description;
 
             if (webModel.LCID > 0)
                 web.Locale = new CultureInfo((int)webModel.LCID);
@@ -76,6 +76,12 @@ namespace SPMeta2.SSOM.ModelHandlers
 
             if (!string.IsNullOrEmpty(webModel.SiteLogoUrl))
                 web.SiteLogoUrl = webModel.SiteLogoUrl;
+
+            if (webModel.IndexedPropertyKeys.Any())
+            {
+                foreach (var indexProperty in webModel.IndexedPropertyKeys)
+                    web.IndexedPropertyKeys.Add(indexProperty);
+            }
         }
 
         public override void WithResolvingModelHost(ModelHostResolveContext modelHostContext)
@@ -84,8 +90,7 @@ namespace SPMeta2.SSOM.ModelHandlers
             var model = modelHostContext.Model;
             var childModelType = modelHostContext.ChildModelType;
             var action = modelHostContext.Action;
-
-
+            
             var webDefinition = model as WebDefinition;
             SPWeb parentWeb = null;
 

--- a/SPMeta2/SPMeta2/Definitions/WebDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/WebDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+
 using SPMeta2.Attributes;
 using SPMeta2.Attributes.Capabilities;
 using SPMeta2.Attributes.Identity;
@@ -42,6 +43,7 @@ namespace SPMeta2.Definitions
 
             TitleResource = new List<ValueForUICulture>();
             DescriptionResource = new List<ValueForUICulture>();
+            IndexedPropertyKeys = new List<string>();
         }
 
         #endregion
@@ -150,6 +152,13 @@ namespace SPMeta2.Definitions
         //[ExpectUpdateAsUrl(Extension = ".css")]
         [ExpectNullable]
         public string AlternateCssUrl { get; set; }
+
+        /// <summary>
+        /// Gets the set of property keys for properties that need to be exposed through Site Data Web Service.
+        /// </summary>
+        [DataMember]
+        [ExpectValidation]
+        public List<string> IndexedPropertyKeys { get; set; }
 
         #endregion
 


### PR DESCRIPTION
There are a few things I'm not sure about this fix for #749 

1. I've hardcoded the propertybag name "vti_indexedpropertykeys" into the code. I'm not happy about that, but I couldn't find the place to put.
2. For CSOM WebModelHandler I added context.Update and ExecuteQueryWithTrace right away, because I wasn't sure if later code would override my changes. Maybe that's not needed at all, maybe it breaks something coming afterwards, but I couldn't test csom.
3. I've added GetEncodedValueForSearchIndexProperty method into WebModelHandler.cs but I don't think it's the right place, especially because I used the method for webvalidator aswell.

Let's see what you have to say about it ;-)