### PR TITLE
Fix #807: DependendLookupFieldHandler now uses ID and InternalName properties

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
@@ -1,21 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using Microsoft.SharePoint.Client;
-using SPMeta2.Common;
-using SPMeta2.CSOM.Extensions;
-using SPMeta2.CSOM.ModelHosts;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
-using SPMeta2.Exceptions;
-using SPMeta2.Services;
 using SPMeta2.Utils;
+using SPMeta2.CSOM.Extensions;
+using System.Xml.Linq;
+using SPMeta2.Enumerations;
+using SPMeta2.Exceptions;
 
 namespace SPMeta2.CSOM.ModelHandlers.Fields
 {
-    public class DependentLookupFieldModelHandler : CSOMModelHandlerBase
+    public class DependentLookupFieldModelHandler : FieldModelHandler
     {
         #region properties
 
@@ -23,207 +18,99 @@ namespace SPMeta2.CSOM.ModelHandlers.Fields
         {
             get { return typeof(DependentLookupFieldDefinition); }
         }
+
+        protected override Type GetTargetFieldType(FieldDefinition model)
+        {
+            return typeof(FieldLookup);
+        }
+
         #endregion
 
         #region methods
 
-        public override void DeployModel(object modelHost, DefinitionBase model)
+        protected override void ProcessFieldProperties(Field field, FieldDefinition fieldModel)
         {
-            var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            var site = HostSite;
+            var context = site.Context;
 
-            if (modelHost is SiteModelHost)
-                DeploySiteDependentLookup(modelHost, modelHost as SiteModelHost, definition);
-            else if (modelHost is WebModelHost)
-                DeployWebDependentLookup(modelHost, modelHost as WebModelHost, definition);
-            else if (modelHost is ListModelHost)
-                DeployListDependentLookup(modelHost, modelHost as ListModelHost, definition);
-        }
+            // let base setting be setup
+            base.ProcessFieldProperties(field, fieldModel);
 
-        private void DeployListDependentLookup(object modelHost, ListModelHost listModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, listModelHost.HostList.Fields, definition);
-        }
+            var typedField = field.Context.CastTo<FieldLookup>(field);
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
 
-        private void DeployWebDependentLookup(object modelHost, WebModelHost webModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, webModelHost.HostWeb.Fields, definition);
-        }
-
-        private void DeploySiteDependentLookup(object modelHost, SiteModelHost siteModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, siteModelHost.HostSite.RootWeb.Fields, definition);
-        }
-
-        protected virtual FieldLookup GetField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetDependentLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetDependentLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetDependentLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        protected virtual FieldLookup GetPrimaryField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetPrimaryLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetPrimaryLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetPrimaryLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        private void DeployDependentLookupField(object modelHost, FieldCollection fields, DependentLookupFieldDefinition definition)
-        {
-            var context = fields.Context;
-
-            var primaryLookupField = GetPrimaryLookupField(fields, definition);
-            var dependentLookupField = GetDependentLookupField(fields, definition);
-
-            if (dependentLookupField == null)
+            if (!typedField.IsPropertyAvailable("PrimaryFieldId"))
             {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = null,
-                    ObjectType = typeof(FieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
-                var internalName = fields.AddDependentLookup(definition.InternalName, primaryLookupField, definition.LookupField);
-
-                dependentLookupField = GetDependentLookupField(fields, definition);
-                dependentLookupField.Title = definition.Title;
-
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
-                dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
-
-                if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
-                {
-                    dependentLookupField.LookupList = primaryLookupField.LookupList;
-                }
-
-                if (string.IsNullOrEmpty(dependentLookupField.PrimaryFieldId))
-                    dependentLookupField.PrimaryFieldId = primaryLookupField.Id.ToString();
-
-                dependentLookupField.ReadOnlyField = true;
-                dependentLookupField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
-
-                // unsuppoeted in CSOM yet
-                //dependentLookupField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
-                dependentLookupField.Direction = primaryLookupField.Direction;
-            }
-            else
-            {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = dependentLookupField,
-                    ObjectType = typeof(FieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
+                typedField.Context.Load(typedField, f => f.PrimaryFieldId);
+                typedField.Context.ExecuteQueryWithTrace();
             }
 
-            dependentLookupField.Title = definition.Title;
+            var primaryLookupField = GetPrimaryField(typedFieldModel);
 
-            dependentLookupField.LookupField = definition.LookupField;
+            typedField.Context.Load(primaryLookupField);
+            typedField.Context.ExecuteQueryWithTrace();
 
-            if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
+//            var primaryLookupField = field2.TypedObject as FieldLookup;
+
+            typedField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
+            typedField.TypeAsString = primaryLookupField.TypeAsString;
+            typedField.LookupList = primaryLookupField.LookupList;
+            typedField.LookupWebId = primaryLookupField.LookupWebId;
+            if (string.IsNullOrEmpty(typedField.PrimaryFieldId))
             {
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
+                typedField.PrimaryFieldId = primaryLookupField.Id.ToString();
             }
-            dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
+            typedField.ReadOnlyField = true;
 
-            dependentLookupField.Group = string.IsNullOrEmpty(definition.Group) ? "Custom" : definition.Group; 
-            dependentLookupField.Description = definition.Description ?? string.Empty;
+            // unsupported in CSOM yet
+            //dependentLookupField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
+            typedField.Direction = primaryLookupField.Direction;
+            typedField.LookupField = typedFieldModel.LookupField;
 
-            InvokeOnModelEvent(this, new ModelEventArgs
-            {
-                CurrentModelNode = null,
-                Model = null,
-                EventType = ModelEventType.OnProvisioned,
-                Object = dependentLookupField,
-                ObjectType = typeof(FieldLookup),
-                ObjectDefinition = definition,
-                ModelHost = modelHost
-            });
-
-            dependentLookupField.UpdateAndPushChanges(true);
-
-            context.ExecuteQueryWithTrace();
+            typedField.Group = typedFieldModel.Group ?? string.Empty;
+            typedField.Description = typedFieldModel.Description ?? string.Empty;
+            typedField.Title = typedFieldModel.Title;
         }
 
-        protected virtual FieldLookup GetDependentLookupField(FieldCollection fields, 
-            DependentLookupFieldDefinition definition)
+        protected virtual FieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)
         {
-            var context = fields.Context;
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
 
-            Field field = null;
-
-            var scope = new ExceptionHandlingScope(context);
-
-            using (scope.StartScope())
-            {
-                using (scope.StartTry())
-                {
-                    fields.GetByInternalNameOrTitle(definition.InternalName);
-                }
-
-                using (scope.StartCatch())
-                {
-
-                }
-            }
-
-            TraceService.Verbose((int)LogEventId.ModelProvisionCoreCall, "ExecuteQuery()");
-            context.ExecuteQueryWithTrace();
-
-            if (!scope.HasException)
-            {
-                field = fields.GetByInternalNameOrTitle(definition.InternalName);
-                context.Load(field);
-
-                context.ExecuteQueryWithTrace();
-
-                return context.CastTo<FieldLookup>(field);
-            }
-
-            return null;
+            return FieldLookupService.GetFieldAs<FieldLookup>(
+                fields, definition.PrimaryLookupFieldId, definition.PrimaryLookupFieldInternalName, definition.PrimaryLookupFieldTitle);
         }
-
-        protected virtual FieldLookup GetPrimaryLookupField(FieldCollection fields, DependentLookupFieldDefinition definition)
+        
+        protected override void ProcessSPFieldXElement(XElement fieldTemplate, FieldDefinition fieldModel)
         {
-            var context = fields.Context;
+            var site = HostSite;
+            var context = HostSite.Context;
 
-            Field result = null;
+            base.ProcessSPFieldXElement(fieldTemplate, fieldModel);
 
-            if (definition.PrimaryLookupFieldId.HasGuidValue())
-                result = fields.GetById(definition.PrimaryLookupFieldId.Value);
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
 
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
-                result = fields.GetByInternalNameOrTitle(definition.PrimaryLookupFieldInternalName);
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.Mult, typedFieldModel.AllowMultipleValues.ToString().ToUpper());
 
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
-                result = fields.GetByTitle(definition.PrimaryLookupFieldTitle);
+            if (typedFieldModel.LookupWebId.HasGuidValue())
+            {
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.WebId, typedFieldModel.LookupWebId.Value.ToString("B"));
+            }
 
-            context.Load(result);
-            context.ExecuteQueryWithTrace();
+            if (!string.IsNullOrEmpty(typedFieldModel.LookupList))
+            {
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.List, typedFieldModel.LookupList);
+            }
+            
+            if (!string.IsNullOrEmpty(typedFieldModel.LookupField))
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.ShowField, typedFieldModel.LookupField);
 
-            return context.CastTo<FieldLookup>(result);
+            Field primaryField = GetPrimaryField(typedFieldModel);
+            if (primaryField == null)
+            {
+                throw new SPMeta2Exception("PrimaryLookupField need to be defined when creating a DependentLookupField");
+            }
+
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.FieldReference, primaryField.Id.ToString("B"));
         }
 
         #endregion

--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
@@ -50,8 +50,6 @@ namespace SPMeta2.CSOM.ModelHandlers.Fields
             typedField.Context.Load(primaryLookupField);
             typedField.Context.ExecuteQueryWithTrace();
 
-//            var primaryLookupField = field2.TypedObject as FieldLookup;
-
             typedField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
             typedField.TypeAsString = primaryLookupField.TypeAsString;
             typedField.LookupList = primaryLookupField.LookupList;
@@ -66,10 +64,6 @@ namespace SPMeta2.CSOM.ModelHandlers.Fields
             //dependentLookupField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
             typedField.Direction = primaryLookupField.Direction;
             typedField.LookupField = typedFieldModel.LookupField;
-
-            typedField.Group = typedFieldModel.Group ?? string.Empty;
-            typedField.Description = typedFieldModel.Description ?? string.Empty;
-            typedField.Title = typedFieldModel.Title;
         }
 
         protected virtual FieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)

--- a/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
+++ b/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
@@ -1,15 +1,132 @@
 ﻿using SPMeta2.Definitions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using Microsoft.SharePoint.Client;
+using SPMeta2.Utils;
+using SPMeta2.Exceptions;
+using SPMeta2.CSOM.ModelHosts;
+using SPMeta2.CSOM.Extensions;
 
 namespace SPMeta2.CSOM.Services
 {
     public class CSOMFieldLookupService
     {
+        public virtual FieldCollection GetFieldCollection(object modelHost)
+        {
+            if (modelHost is SiteModelHost)
+                return (modelHost as SiteModelHost).HostSite.RootWeb.Fields;
+            else if (modelHost is WebModelHost)
+                return (modelHost as WebModelHost).HostWeb.Fields;
+            else if (modelHost is ListModelHost)
+                return (modelHost as ListModelHost).HostList.Fields;
+
+            throw new SPMeta2Exception("Unsupported model host");
+        }
+
+        public virtual Field GetField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
+        {
+            if (fieldId.HasGuidValue())
+                return fields.GetById(fieldId.Value);
+
+            if (!string.IsNullOrEmpty(fieldInternalName))
+                return fields.GetByInternalNameOrTitle(fieldInternalName);
+
+            if (!string.IsNullOrEmpty(fieldTitle))
+                return fields.GetByTitle(fieldTitle);
+
+            throw new SPMeta2Exception("GetField(): on of fieldId / fieldInternalName / fieldTitle needs to be defined");
+        }
+
+        public virtual T GetFieldAs<T>(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle) where T : Field
+        {
+            var field = GetField(fields, fieldId, fieldInternalName, fieldTitle);
+
+            return fields.Context.CastTo<T>(field);
+        }
+
+        public virtual Field FindField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
+        {
+            var context = fields.Context;
+
+            var scope = new ExceptionHandlingScope(context);
+
+            Field field = null;
+
+            if (fieldId.HasGuidValue())
+            {
+                var id = fieldId.Value;
+
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetById(id);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(fieldInternalName))
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetByInternalNameOrTitle(fieldInternalName);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(fieldTitle))
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetByTitle(fieldTitle);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+
+            context.ExecuteQueryWithTrace();
+
+            if (!scope.HasException)
+            {
+                if (fieldId.HasGuidValue())
+                {
+                    field = fields.GetById(fieldId.Value);
+                }
+                else if (!string.IsNullOrEmpty(fieldInternalName))
+                {
+                    field = fields.GetByInternalNameOrTitle(fieldInternalName);
+                }
+                else if (!string.IsNullOrEmpty(fieldTitle))
+                {
+                    field = fields.GetByTitle(fieldTitle);
+                }
+
+                context.Load(field);
+                context.Load(field, f => f.SchemaXml);
+
+                context.ExecuteQueryWithTrace();
+            }
+
+            return field;
+        }
+
         public virtual void EnsureDefaultValues(ListItem item, List<FieldValue> defaultValues)
         {
             EnsureValues(item, defaultValues, false);

--- a/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
+++ b/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
@@ -24,19 +24,7 @@ namespace SPMeta2.CSOM.Services
             throw new SPMeta2Exception("Unsupported model host");
         }
 
-        public virtual Field GetField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
-        {
-            if (fieldId.HasGuidValue())
-                return fields.GetById(fieldId.Value);
 
-            if (!string.IsNullOrEmpty(fieldInternalName))
-                return fields.GetByInternalNameOrTitle(fieldInternalName);
-
-            if (!string.IsNullOrEmpty(fieldTitle))
-                return fields.GetByTitle(fieldTitle);
-
-            throw new SPMeta2Exception("GetField(): on of fieldId / fieldInternalName / fieldTitle needs to be defined");
-        }
 
         public virtual T GetFieldAs<T>(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle) where T : Field
         {
@@ -45,7 +33,7 @@ namespace SPMeta2.CSOM.Services
             return fields.Context.CastTo<T>(field);
         }
 
-        public virtual Field FindField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
+        public virtual Field GetField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
         {
             var context = fields.Context;
 

--- a/SPMeta2/SPMeta2.Containers/DefinitionGenerators/Fields/DependentLookupFieldDefinitionGenerator.cs
+++ b/SPMeta2/SPMeta2.Containers/DefinitionGenerators/Fields/DependentLookupFieldDefinitionGenerator.cs
@@ -17,7 +17,9 @@ namespace SPMeta2.Containers.DefinitionGenerators.Fields
         {
             return WithEmptyDefinition(def =>
             {
+                def.Id = Rnd.Guid();
                 def.Title = Rnd.String(12);
+                def.Group = Rnd.String(12);
                 def.InternalName = string.Format("iname_{0}", Rnd.String(12));
 
                 def.PrimaryLookupFieldId = PrimaryLookupField.Id;

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/ClientFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/ClientFieldDefinitionValidator.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Xml.Linq;
 using Microsoft.SharePoint.Client;
 using SPMeta2.Containers.Assertion;
 using SPMeta2.CSOM.Extensions;
 using SPMeta2.CSOM.ModelHandlers;
-using SPMeta2.CSOM.ModelHosts;
 using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
 using SPMeta2.Enumerations;
-using SPMeta2.Exceptions;
 using SPMeta2.Regression.CSOM.Utils;
 using SPMeta2.Services;
 using SPMeta2.Utils;
@@ -45,23 +41,6 @@ namespace SPMeta2.Regression.CSOM.Validation
         }
         protected List HostList { get; set; }
         // protected Site HostSite { get; set; }
-
-        protected Field GetField(object modelHost, FieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return FindExistingSiteField(modelHost as SiteModelHost, definition);
-            if (modelHost is WebModelHost)
-                return FindExistingWebField(modelHost as WebModelHost, definition);
-            else if (modelHost is ListModelHost)
-                return FindExistingListField((modelHost as ListModelHost).HostList, definition);
-            else
-            {
-                throw new SPMeta2NotSupportedException(
-                    string.Format("Validation for artifact of type [{0}] under model host [{1}] is not supported.",
-                    definition.GetType(),
-                    modelHost.GetType()));
-            }
-        }
 
         protected virtual void CustomFieldTypeValidation(AssertPair<FieldDefinition, Field> assert, Field spObject,
            FieldDefinition definition)
@@ -348,5 +327,4 @@ namespace SPMeta2.Regression.CSOM.Validation
             }
         }
     }
-
 }

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/BusinessDataFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/BusinessDataFieldDefinitionValidator.cs
@@ -1,18 +1,9 @@
-﻿using SPMeta2.CSOM.ModelHandlers.Fields;
-using SPMeta2.CSOM.ModelHosts;
-using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
+﻿using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using SPMeta2.Regression.CSOM.Utils;
 using SPMeta2.Utils;
-using Microsoft.SharePoint.Client;
-using SPMeta2.Exceptions;
-using System.Xml.Linq;
 
 namespace SPMeta2.Regression.CSOM.Validation.Fields
 {
@@ -28,7 +19,7 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
             base.DeployModel(modelHost, model);
 
             var definition = model.WithAssertAndCast<BusinessDataFieldDefinition>("model", value => value.RequireNotNull());
-            var spObject = FindField(modelHost, definition);
+            var spObject = GetField(modelHost, definition);
 
             var assert = ServiceFactory.AssertService
                                        .NewAssert(model, definition, spObject);

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
@@ -1,22 +1,29 @@
 ﻿using System.Linq;
 using Microsoft.SharePoint.Client;
 using SPMeta2.Containers.Assertion;
-using SPMeta2.CSOM.ModelHandlers.Fields;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using SPMeta2.Exceptions;
 using SPMeta2.Services;
 using SPMeta2.Utils;
+using System;
 
 namespace SPMeta2.Regression.CSOM.Validation.Fields
 {
-    public class DependentLookupFieldDefinitionValidator : DependentLookupFieldModelHandler
+    public class DependentLookupFieldDefinitionValidator : ClientFieldDefinitionValidator
     {
+        public override Type TargetType
+        {
+            get
+            {
+                return typeof(DependentLookupFieldDefinition);
+            }
+        }
 
         public override void DeployModel(object modelHost, DefinitionBase model)
         {
             var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
-            var spObject = GetField(modelHost, definition);
+            var spObject = GetField(modelHost, definition) as FieldLookup;
 
             var assert = ServiceFactory.AssertService.NewAssert(model, definition, spObject);
 
@@ -91,7 +98,7 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
 
             if (definition.PrimaryLookupFieldId.HasGuidValue())
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -112,7 +119,7 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
 
             if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -133,7 +140,7 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
 
             if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -242,6 +249,13 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
                 assert.SkipProperty(m => m.TitleResource, "TitleResource is null or empty. Skipping.");
                 assert.SkipProperty(m => m.DescriptionResource, "DescriptionResource is null or empty. Skipping.");
             }
+        }
+
+        protected virtual FieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)
+        {
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
+
+            return FieldLookupService.GetFieldAs<FieldLookup>(fields, definition.PrimaryLookupFieldId, definition.PrimaryLookupFieldInternalName, definition.PrimaryLookupFieldTitle);
         }
     }
 }

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
@@ -22,8 +22,11 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
 
         public override void DeployModel(object modelHost, DefinitionBase model)
         {
+            this.ModelHost = modelHost;
+
             var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
-            var spObject = GetField(modelHost, definition) as FieldLookup;
+            var spObjectTmp = GetField(modelHost, definition);
+            var spObject = spObjectTmp.Context.CastTo<FieldLookup>(spObjectTmp);
 
             var assert = ServiceFactory.AssertService.NewAssert(model, definition, spObject);
 

--- a/SPMeta2/SPMeta2.Regression.SSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.SSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
@@ -11,8 +11,17 @@ namespace SPMeta2.Regression.SSOM.Validation.Fields
 {
     public class DependentLookupFieldDefinitionValidator : FieldDefinitionValidator
     {
+        public override Type TargetType
+        {
+            get
+            {
+                return typeof(DependentLookupFieldDefinition);
+            }
+        }
+
         public override void DeployModel(object modelHost, DefinitionBase model)
         {
+            this.ModelHost = modelHost;
             var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
             var spObject = GetField(modelHost, definition) as SPFieldLookup;
 

--- a/SPMeta2/SPMeta2.Regression.SSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.SSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
@@ -3,20 +3,18 @@ using System.Linq;
 using Microsoft.SharePoint;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
-using SPMeta2.SSOM.ModelHandlers.Fields;
 using SPMeta2.Utils;
 using SPMeta2.Containers.Assertion;
 using SPMeta2.Exceptions;
 
 namespace SPMeta2.Regression.SSOM.Validation.Fields
 {
-    public class DependentLookupFieldDefinitionValidator : DependentLookupFieldModelHandler
+    public class DependentLookupFieldDefinitionValidator : FieldDefinitionValidator
     {
-
         public override void DeployModel(object modelHost, DefinitionBase model)
         {
             var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
-            var spObject = GetField(modelHost, definition);
+            var spObject = GetField(modelHost, definition) as SPFieldLookup;
 
             var assert = ServiceFactory.AssertService.NewAssert(model, definition, spObject);
 
@@ -89,7 +87,7 @@ namespace SPMeta2.Regression.SSOM.Validation.Fields
 
             if (definition.PrimaryLookupFieldId.HasGuidValue())
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -110,7 +108,7 @@ namespace SPMeta2.Regression.SSOM.Validation.Fields
 
             if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -131,7 +129,7 @@ namespace SPMeta2.Regression.SSOM.Validation.Fields
 
             if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                var primaryLookupField = GetPrimaryField(definition);
 
                 assert.ShouldBeEqual((p, s, d) =>
                 {
@@ -215,6 +213,14 @@ namespace SPMeta2.Regression.SSOM.Validation.Fields
             {
                 assert.SkipProperty(m => m.DescriptionResource, "DescriptionResource is NULL or empty. Skipping.");
             }
+        }
+
+        protected virtual SPFieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)
+        {
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
+
+            return FieldLookupService.GetFieldAs<SPFieldLookup>(
+                fields, definition.PrimaryLookupFieldId, definition.PrimaryLookupFieldInternalName, definition.PrimaryLookupFieldTitle);
         }
     }
 }

--- a/SPMeta2/SPMeta2.SSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
+++ b/SPMeta2/SPMeta2.SSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
@@ -1,18 +1,15 @@
 ﻿using System;
-using System.Linq;
 using System.Xml.Linq;
 using Microsoft.SharePoint;
-using SPMeta2.Common;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using SPMeta2.Enumerations;
-using SPMeta2.SSOM.ModelHosts;
 using SPMeta2.Utils;
 using SPMeta2.Exceptions;
 
 namespace SPMeta2.SSOM.ModelHandlers.Fields
 {
-    public class DependentLookupFieldModelHandler : SSOMModelHandlerBase
+    public class DependentLookupFieldModelHandler : FieldModelHandler
     {
         #region properties
 
@@ -20,175 +17,79 @@ namespace SPMeta2.SSOM.ModelHandlers.Fields
         {
             get { return typeof(DependentLookupFieldDefinition); }
         }
+
+        protected override Type GetTargetFieldType(FieldDefinition model)
+        {
+            return typeof(SPFieldLookup);
+        }
+
         #endregion
 
         #region methods
 
-        public override void DeployModel(object modelHost, DefinitionBase model)
+        protected override void ProcessFieldProperties(SPField field, FieldDefinition fieldModel)
         {
-            var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            // let base setting be setup
+            base.ProcessFieldProperties(field, fieldModel);
 
-            if (modelHost is SiteModelHost)
-                DeploySiteDependentLookup(modelHost, modelHost as SiteModelHost, definition);
-            else if (modelHost is WebModelHost)
-                DeployWebDependentLookup(modelHost, modelHost as WebModelHost, definition);
-            else if (modelHost is ListModelHost)
-                DeployListDependentLookup(modelHost, modelHost as ListModelHost, definition);
+            var typedField = field as SPFieldLookup;
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+
+            var primaryLookupField = GetPrimaryField(typedFieldModel);
+
+            typedField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
+            typedField.TypeAsString = primaryLookupField.TypeAsString;
+            typedField.LookupList = primaryLookupField.LookupList;
+            typedField.LookupWebId = primaryLookupField.LookupWebId;
+            typedField.ReadOnlyField = true;
+            typedField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
+            typedField.Direction = primaryLookupField.Direction;
+            typedField.LookupField = typedFieldModel.LookupField;
+
+            typedField.Group = typedFieldModel.Group ?? string.Empty;
+            typedField.Description = typedFieldModel.Description ?? string.Empty;
+            typedField.Title = typedFieldModel.Title;
         }
-
-        private void DeployListDependentLookup(object modelHost, ListModelHost listModelHost, DependentLookupFieldDefinition definition)
+        
+        protected override void ProcessSPFieldXElement(XElement fieldTemplate, FieldDefinition fieldModel)
         {
-            DeployDependentLookupField(modelHost, listModelHost.HostList.Fields, definition);
-        }
+            base.ProcessSPFieldXElement(fieldTemplate, fieldModel);
 
-        private void DeployWebDependentLookup(object modelHost, WebModelHost webModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, webModelHost.HostWeb.Fields, definition);
-        }
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
 
-        private void DeploySiteDependentLookup(object modelHost, SiteModelHost siteModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, siteModelHost.HostSite.RootWeb.Fields, definition);
-        }
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.Mult, typedFieldModel.AllowMultipleValues.ToString().ToUpper());
 
-        protected virtual SPFieldLookup GetField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetDependentLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetDependentLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetDependentLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        protected virtual SPFieldLookup GetPrimaryField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetPrimaryLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetPrimaryLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetPrimaryLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        private void DeployDependentLookupField(object modelHost, SPFieldCollection fields, DependentLookupFieldDefinition definition)
-        {
-            var primaryLookupField = GetPrimaryLookupField(fields, definition);
-            var dependentLookupField = GetDependentLookupField(fields, definition);
-
-            if (dependentLookupField == null)
+            if (typedFieldModel.LookupWebId.HasGuidValue())
             {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = null,
-                    ObjectType = typeof(SPFieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
-                var internalName = fields.AddDependentLookup(definition.InternalName, primaryLookupField.Id);
-
-                //dependentLookupField = (SPFieldLookup)fields.CreateNewField(SPFieldType.Lookup.ToString(), definition.InternalName);
-
-                dependentLookupField = GetDependentLookupField(fields, definition);
-                dependentLookupField.Title = definition.Title;
-
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
-                dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
-
-                if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
-                {
-                    dependentLookupField.LookupList = primaryLookupField.LookupList;
-                }
-
-                if (string.IsNullOrEmpty(dependentLookupField.PrimaryFieldId))
-                    dependentLookupField.PrimaryFieldId = primaryLookupField.Id.ToString();
-
-                dependentLookupField.ReadOnlyField = true;
-                dependentLookupField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
-                dependentLookupField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
-                dependentLookupField.Direction = primaryLookupField.Direction;
-
-                //dependentLookupField.Update(true);
-                //dependentLookupField = GetDependentLookupField(fields, definition);
-            }
-            else
-            {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = dependentLookupField,
-                    ObjectType = typeof(SPFieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.WebId, typedFieldModel.LookupWebId.Value.ToString("B"));
             }
 
-            dependentLookupField.Title = definition.Title;
-
-            dependentLookupField.LookupField = definition.LookupField;
-
-            if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
+            if (!string.IsNullOrEmpty(typedFieldModel.LookupList))
             {
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.List, typedFieldModel.LookupList);
             }
-            dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
 
-            dependentLookupField.Group = definition.Group ?? string.Empty;
-            dependentLookupField.Description = definition.Description ?? string.Empty;
+            if (!string.IsNullOrEmpty(typedFieldModel.LookupField))
+                fieldTemplate.SetAttribute(BuiltInFieldAttributes.ShowField, typedFieldModel.LookupField);
 
-            InvokeOnModelEvent(this, new ModelEventArgs
+            SPField primaryField = GetPrimaryField(typedFieldModel);
+            if (primaryField == null)
             {
-                CurrentModelNode = null,
-                Model = null,
-                EventType = ModelEventType.OnProvisioned,
-                Object = dependentLookupField,
-                ObjectType = typeof(SPFieldLookup),
-                ObjectDefinition = definition,
-                ModelHost = modelHost
-            });
+                throw new SPMeta2Exception("PrimaryLookupField need to be defined when creating a DependentLookupField");
+            }
 
-            if (fields.List != null)
-                dependentLookupField.Update();
-            else
-                dependentLookupField.Update(true);
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.FieldReference, primaryField.Id.ToString("B"));
         }
 
-        protected virtual SPFieldLookup GetDependentLookupField(SPFieldCollection fields, DependentLookupFieldDefinition definition)
+        protected virtual SPFieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)
         {
-            var targetName = definition.InternalName.ToUpper();
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
 
-            return fields
-                     .OfType<SPField>()
-                     .FirstOrDefault(f => f.InternalName.ToUpper() == targetName) as SPFieldLookup;
-        }
-
-        protected virtual SPFieldLookup GetPrimaryLookupField(SPFieldCollection fields, DependentLookupFieldDefinition definition)
-        {
-            if (definition.PrimaryLookupFieldId.HasGuidValue())
-                return fields[definition.PrimaryLookupFieldId.Value] as SPFieldLookup;
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
-                return fields.GetFieldByInternalName(definition.PrimaryLookupFieldInternalName) as SPFieldLookup; ;
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
-                return fields.GetField(definition.PrimaryLookupFieldTitle) as SPFieldLookup; ;
-
-            throw new SPMeta2Exception("PrimaryLookupFieldTitle / PrimaryLookupFieldInternalName / PrimaryLookupFieldId need to be defined");
+            return FieldLookupService.GetFieldAs<SPFieldLookup>(
+                fields, definition.PrimaryLookupFieldId, definition.PrimaryLookupFieldInternalName, definition.PrimaryLookupFieldTitle);
         }
 
         #endregion
     }
+    
 }

--- a/SPMeta2/SPMeta2/Definitions/Fields/DependentLookupFieldDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/Fields/DependentLookupFieldDefinition.cs
@@ -20,8 +20,8 @@ namespace SPMeta2.Definitions.Fields
     [Serializable]
     [DataContract]
     [ExpectArrayExtensionMethod]
-    [ExpectManyInstances]
 
+    [ExpectManyInstances]
     public class DependentLookupFieldDefinition : LookupFieldDefinition
     {
         #region properties
@@ -31,7 +31,7 @@ namespace SPMeta2.Definitions.Fields
         /// </summary>
         /// 
         [ExpectValidation]
-        //[ExpectRequired]
+        [ExpectRequired]
         [DataMember]
         [IdentityKey]
         public override Guid Id { get; set; }

--- a/SPMeta2/SPMeta2/Enumerations/BuiltInFieldAttributes.cs
+++ b/SPMeta2/SPMeta2/Enumerations/BuiltInFieldAttributes.cs
@@ -83,6 +83,8 @@ namespace SPMeta2.Enumerations
 
         public static string Format = "Format";
 
+        public static string FieldReference = "FieldRef";
+
         #endregion
     }
 }


### PR DESCRIPTION
- Rewrote DependendLookupFieldHandler to have control over which ID and InternalName will be used
- Minor refactoring regarding field lookups
- No regression testing performed yet