### PR TITLE
DependentLookupFieldHandler: Support ID and InternalName (#807)

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
+++ b/SPMeta2/SPMeta2.CSOM/Services/CSOMFieldLookupService.cs
@@ -1,15 +1,120 @@
 ﻿using SPMeta2.Definitions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using Microsoft.SharePoint.Client;
+using SPMeta2.Utils;
+using SPMeta2.Exceptions;
+using SPMeta2.CSOM.ModelHosts;
+using SPMeta2.CSOM.Extensions;
 
 namespace SPMeta2.CSOM.Services
 {
     public class CSOMFieldLookupService
     {
+        public virtual FieldCollection GetFieldCollection(object modelHost)
+        {
+            if (modelHost is SiteModelHost)
+                return (modelHost as SiteModelHost).HostSite.RootWeb.Fields;
+            else if (modelHost is WebModelHost)
+                return (modelHost as WebModelHost).HostWeb.Fields;
+            else if (modelHost is ListModelHost)
+                return (modelHost as ListModelHost).HostList.Fields;
+
+            throw new SPMeta2Exception("Unsupported model host");
+        }
+
+
+
+        public virtual T GetFieldAs<T>(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle) where T : Field
+        {
+            var field = GetField(fields, fieldId, fieldInternalName, fieldTitle);
+
+            return fields.Context.CastTo<T>(field);
+        }
+
+        public virtual Field GetField(FieldCollection fields, Guid? fieldId, string fieldInternalName, string fieldTitle)
+        {
+            var context = fields.Context;
+
+            var scope = new ExceptionHandlingScope(context);
+
+            Field field = null;
+
+            if (fieldId.HasGuidValue())
+            {
+                var id = fieldId.Value;
+
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetById(id);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(fieldInternalName))
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetByInternalNameOrTitle(fieldInternalName);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+            else if (!string.IsNullOrEmpty(fieldTitle))
+            {
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        fields.GetByTitle(fieldTitle);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+
+                    }
+                }
+            }
+
+            context.ExecuteQueryWithTrace();
+
+            if (!scope.HasException)
+            {
+                if (fieldId.HasGuidValue())
+                {
+                    field = fields.GetById(fieldId.Value);
+                }
+                else if (!string.IsNullOrEmpty(fieldInternalName))
+                {
+                    field = fields.GetByInternalNameOrTitle(fieldInternalName);
+                }
+                else if (!string.IsNullOrEmpty(fieldTitle))
+                {
+                    field = fields.GetByTitle(fieldTitle);
+                }
+
+                context.Load(field);
+                context.Load(field, f => f.SchemaXml);
+
+                context.ExecuteQueryWithTrace();
+            }
+
+            return field;
+        }
+
         public virtual void EnsureDefaultValues(ListItem item, List<FieldValue> defaultValues)
         {
             EnsureValues(item, defaultValues, false);

--- a/SPMeta2/SPMeta2.Containers/DefinitionGenerators/Fields/DependentLookupFieldDefinitionGenerator.cs
+++ b/SPMeta2/SPMeta2.Containers/DefinitionGenerators/Fields/DependentLookupFieldDefinitionGenerator.cs
@@ -17,10 +17,17 @@ namespace SPMeta2.Containers.DefinitionGenerators.Fields
         {
             return WithEmptyDefinition(def =>
             {
+                def.Id = Rnd.Guid();
                 def.Title = Rnd.String(12);
+                def.Group = Rnd.String(12);
                 def.InternalName = string.Format("iname_{0}", Rnd.String(12));
 
+                def.LookupField = PrimaryLookupField.LookupField;
+                def.LookupList = PrimaryLookupField.LookupList;
+                def.LookupWebId = PrimaryLookupField.LookupWebId;
+
                 def.PrimaryLookupFieldId = PrimaryLookupField.Id;
+                def.AllowMultipleValues = PrimaryLookupField.AllowMultipleValues;
             });
         }
 

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/ClientFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/ClientFieldDefinitionValidator.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Xml.Linq;
 using Microsoft.SharePoint.Client;
 using SPMeta2.Containers.Assertion;
 using SPMeta2.CSOM.Extensions;
 using SPMeta2.CSOM.ModelHandlers;
-using SPMeta2.CSOM.ModelHosts;
 using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
 using SPMeta2.Enumerations;
-using SPMeta2.Exceptions;
 using SPMeta2.Regression.CSOM.Utils;
 using SPMeta2.Services;
 using SPMeta2.Utils;
@@ -45,23 +41,6 @@ namespace SPMeta2.Regression.CSOM.Validation
         }
         protected List HostList { get; set; }
         // protected Site HostSite { get; set; }
-
-        protected Field GetField(object modelHost, FieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return FindExistingSiteField(modelHost as SiteModelHost, definition);
-            if (modelHost is WebModelHost)
-                return FindExistingWebField(modelHost as WebModelHost, definition);
-            else if (modelHost is ListModelHost)
-                return FindExistingListField((modelHost as ListModelHost).HostList, definition);
-            else
-            {
-                throw new SPMeta2NotSupportedException(
-                    string.Format("Validation for artifact of type [{0}] under model host [{1}] is not supported.",
-                    definition.GetType(),
-                    modelHost.GetType()));
-            }
-        }
 
         protected virtual void CustomFieldTypeValidation(AssertPair<FieldDefinition, Field> assert, Field spObject,
            FieldDefinition definition)
@@ -348,5 +327,4 @@ namespace SPMeta2.Regression.CSOM.Validation
             }
         }
     }
-
 }

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/BusinessDataFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/BusinessDataFieldDefinitionValidator.cs
@@ -1,18 +1,9 @@
-﻿using SPMeta2.CSOM.ModelHandlers.Fields;
-using SPMeta2.CSOM.ModelHosts;
-using SPMeta2.Definitions;
-using SPMeta2.Definitions.Base;
+﻿using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using SPMeta2.Regression.CSOM.Utils;
 using SPMeta2.Utils;
-using Microsoft.SharePoint.Client;
-using SPMeta2.Exceptions;
-using System.Xml.Linq;
 
 namespace SPMeta2.Regression.CSOM.Validation.Fields
 {
@@ -28,7 +19,7 @@ namespace SPMeta2.Regression.CSOM.Validation.Fields
             base.DeployModel(modelHost, model);
 
             var definition = model.WithAssertAndCast<BusinessDataFieldDefinition>("model", value => value.RequireNotNull());
-            var spObject = FindField(modelHost, definition);
+            var spObject = GetField(modelHost, definition);
 
             var assert = ServiceFactory.AssertService
                                        .NewAssert(model, definition, spObject);

--- a/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.CSOM/Validation/Fields/DependentLookupFieldDefinitionValidator.cs
@@ -1,246 +1,103 @@
 ﻿using System.Linq;
 using Microsoft.SharePoint.Client;
 using SPMeta2.Containers.Assertion;
-using SPMeta2.CSOM.ModelHandlers.Fields;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using SPMeta2.Exceptions;
 using SPMeta2.Services;
 using SPMeta2.Utils;
+using System;
 
 namespace SPMeta2.Regression.CSOM.Validation.Fields
 {
-    public class DependentLookupFieldDefinitionValidator : DependentLookupFieldModelHandler
+    public class DependentLookupFieldDefinitionValidator : LookupFieldDefinitionValidator
     {
+        public override Type TargetType
+        {
+            get
+            {
+                return typeof(DependentLookupFieldDefinition);
+            }
+        }
 
         public override void DeployModel(object modelHost, DefinitionBase model)
         {
-            var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            this.ModelHost = modelHost;
+
+            base.DeployModel(modelHost, model);
+
+            var definition = model.WithAssertAndCast<FieldDefinition>("model", value => value.RequireNotNull());
             var spObject = GetField(modelHost, definition);
-
-            var assert = ServiceFactory.AssertService.NewAssert(model, definition, spObject);
-
-            assert
-                .ShouldNotBeNull(spObject)
-                .ShouldBeEqual(m => m.Title, o => o.Title)
-                .ShouldBeEqual(m => m.InternalName, o => o.InternalName);
+            var typedField = spObject.Context.CastTo<FieldLookup>(spObject);
+            var typedDefinition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            var typedFieldAssert = ServiceFactory.AssertService.NewAssert(model, typedDefinition, typedField);
 
             var context = spObject.Context;
 
-            // skip base lookup field props
-            assert.SkipProperty(m => m.AddFieldOptions, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.AdditionalAttributes, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.AddToDefaultView, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.AllowDeletion, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.AllowMultipleValues, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.DefaultValue, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.EnforceUniqueValues, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.FieldType, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.Hidden, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.Id, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.Indexed, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.JSLink, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.LookupList, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.LookupListTitle, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.LookupListUrl, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.LookupWebId, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.RawXml, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.Required, "DependentLookupFieldDefinition");
-
-            assert.SkipProperty(m => m.ShowInDisplayForm, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ShowInEditForm, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ShowInListSettings, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ShowInNewForm, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ShowInVersionHistory, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ShowInViewForms, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.StaticName, "DependentLookupFieldDefinition");
-
-            assert.SkipProperty(m => m.ValidationFormula, "DependentLookupFieldDefinition");
-            assert.SkipProperty(m => m.ValidationMessage, "DependentLookupFieldDefinition");
-
-            assert.SkipProperty(m => m.RelationshipDeleteBehavior, "RelationshipDeleteBehavior");
-
-            // web url
-            if (!string.IsNullOrEmpty(definition.LookupWebUrl))
-            {
-                // TODO
-                throw new SPMeta2NotImplementedException("definition.LookupWebUrl");
-            }
+            typedFieldAssert.SkipProperty(m => m.RelationshipDeleteBehavior, "DependentLookupFieldDefinition");
+            
+            if (!string.IsNullOrEmpty(typedDefinition.LookupField))
+                typedFieldAssert.ShouldBeEqual(m => m.LookupField, o => o.LookupField);
             else
-            {
-                assert.SkipProperty(m => m.LookupWebUrl, "LookupWebUrl");
-            }
-
-            if (!string.IsNullOrEmpty(definition.Group))
-                assert.ShouldBeEqual(m => m.Group, o => o.Group);
-            else
-                assert.SkipProperty(m => m.Group);
-
-            if (!string.IsNullOrEmpty(definition.Description))
-                assert.ShouldBeEqual(m => m.Description, o => o.Description);
-            else
-                assert.SkipProperty(m => m.Description);
-
-
-            if (!string.IsNullOrEmpty(definition.LookupField))
-                assert.ShouldBeEqual(m => m.LookupField, o => o.LookupField);
-            else
-                assert.SkipProperty(m => m.LookupField);
+                typedFieldAssert.SkipProperty(m => m.LookupField);
 
             // binding
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
 
-            if (definition.PrimaryLookupFieldId.HasGuidValue())
+            FieldLookup primaryLookupField = null;
+
+            if (typedDefinition.PrimaryLookupFieldId.HasGuidValue())
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                primaryLookupField = FieldLookupService.GetFieldAs<FieldLookup>(fields, typedDefinition.PrimaryLookupFieldId.Value, null, null);
+                typedFieldAssert.ShouldNotBeNull(primaryLookupField);
 
-                assert.ShouldBeEqual((p, s, d) =>
+                typedFieldAssert.ShouldBeEqual((p, s, d) =>
                 {
                     var srcProp = s.GetExpressionValue(m => m.PrimaryLookupFieldId);
-                    var isValid = primaryLookupField.Id == definition.PrimaryLookupFieldId.Value;
+                    var isValid = primaryLookupField.Id == new Guid(typedField.PrimaryFieldId);
 
-                    return new PropertyValidationResult
-                    {
-                        Tag = p.Tag,
-                        Src = srcProp,
-                        Dst = null,
-                        IsValid = isValid
-                    };
+                    return new PropertyValidationResult { Tag = p.Tag, Src = srcProp, Dst = null, IsValid = isValid };
                 });
             }
             else
-                assert.SkipProperty(m => m.PrimaryLookupFieldId, "Value is null or empty.");
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                typedFieldAssert.SkipProperty(m => m.PrimaryLookupFieldId, "PrimaryLookupFieldId is NULL. Skipping.");
+            }
 
-                assert.ShouldBeEqual((p, s, d) =>
+            if (!string.IsNullOrEmpty(typedDefinition.PrimaryLookupFieldInternalName))
+            {
+                primaryLookupField = FieldLookupService.GetFieldAs<FieldLookup>(fields, null, typedDefinition.PrimaryLookupFieldInternalName, null);
+                typedFieldAssert.ShouldNotBeNull(primaryLookupField);
+
+                typedFieldAssert.ShouldBeEqual((p, s, d) =>
                 {
                     var srcProp = s.GetExpressionValue(m => m.PrimaryLookupFieldInternalName);
-                    var isValid = primaryLookupField.InternalName == definition.PrimaryLookupFieldInternalName;
+                    var isValid = primaryLookupField.Id == new Guid(typedField.PrimaryFieldId);
 
-                    return new PropertyValidationResult
-                    {
-                        Tag = p.Tag,
-                        Src = srcProp,
-                        Dst = null,
-                        IsValid = isValid
-                    };
+                    return new PropertyValidationResult { Tag = p.Tag, Src = srcProp, Dst = null, IsValid = isValid };
                 });
             }
             else
-                assert.SkipProperty(m => m.PrimaryLookupFieldInternalName);
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
             {
-                var primaryLookupField = GetPrimaryField(modelHost, definition);
+                typedFieldAssert.SkipProperty(m => m.PrimaryLookupFieldInternalName, "PrimaryLookupFieldInternalName is NULL. Skipping.");
+            }
 
-                assert.ShouldBeEqual((p, s, d) =>
+            if (!string.IsNullOrEmpty(typedDefinition.PrimaryLookupFieldTitle))
+            {
+                primaryLookupField = FieldLookupService.GetFieldAs<FieldLookup>(fields, null, null, typedDefinition.PrimaryLookupFieldTitle);
+                typedFieldAssert.ShouldNotBeNull(primaryLookupField);
+
+                typedFieldAssert.ShouldBeEqual((p, s, d) =>
                 {
                     var srcProp = s.GetExpressionValue(m => m.PrimaryLookupFieldTitle);
-                    var isValid = primaryLookupField.Title == definition.PrimaryLookupFieldTitle;
+                    var isValid = primaryLookupField.Id == new Guid(typedField.PrimaryFieldId);
 
-                    return new PropertyValidationResult
-                    {
-                        Tag = p.Tag,
-                        Src = srcProp,
-                        Dst = null,
-                        IsValid = isValid
-                    };
+                    return new PropertyValidationResult { Tag = p.Tag, Src = srcProp, Dst = null, IsValid = isValid };
                 });
             }
             else
-                assert.SkipProperty(m => m.PrimaryLookupFieldTitle);
-
-            var supportsLocalization = ReflectionUtils.HasProperties(spObject, new[]
             {
-                "TitleResource", "DescriptionResource"
-            });
-
-            if (supportsLocalization)
-            {
-                if (definition.TitleResource.Any())
-                {
-                    assert.ShouldBeEqual((p, s, d) =>
-                    {
-                        var srcProp = s.GetExpressionValue(def => def.TitleResource);
-                        var isValid = true;
-
-                        foreach (var userResource in s.TitleResource)
-                        {
-                            var culture = LocalizationService.GetUserResourceCultureInfo(userResource);
-                            var resourceObject = ReflectionUtils.GetPropertyValue(spObject, "TitleResource");
-
-                            var value = ReflectionUtils.GetMethod(resourceObject, "GetValueForUICulture")
-                                                    .Invoke(resourceObject, new[] { culture.Name }) as ClientResult<string>;
-
-                            context.ExecuteQuery();
-
-                            isValid = userResource.Value == value.Value;
-
-                            if (!isValid)
-                                break;
-                        }
-
-                        return new PropertyValidationResult
-                        {
-                            Tag = p.Tag,
-                            Src = srcProp,
-                            Dst = null,
-                            IsValid = isValid
-                        };
-                    });
-                }
-                else
-                {
-                    assert.SkipProperty(m => m.TitleResource, "TitleResource is NULL or empty. Skipping.");
-                }
-
-                if (definition.DescriptionResource.Any())
-                {
-                    assert.ShouldBeEqual((p, s, d) =>
-                    {
-                        var srcProp = s.GetExpressionValue(def => def.DescriptionResource);
-                        var isValid = true;
-
-                        foreach (var userResource in s.DescriptionResource)
-                        {
-                            var culture = LocalizationService.GetUserResourceCultureInfo(userResource);
-                            var resourceObject = ReflectionUtils.GetPropertyValue(spObject, "DescriptionResource");
-
-                            var value = ReflectionUtils.GetMethod(resourceObject, "GetValueForUICulture")
-                                                       .Invoke(resourceObject, new[] { culture.Name }) as ClientResult<string>;
-
-                            context.ExecuteQuery();
-
-                            isValid = userResource.Value == value.Value;
-
-                            if (!isValid)
-                                break;
-                        }
-
-                        return new PropertyValidationResult
-                        {
-                            Tag = p.Tag,
-                            Src = srcProp,
-                            Dst = null,
-                            IsValid = isValid
-                        };
-                    });
-                }
-                else
-                {
-                    assert.SkipProperty(m => m.DescriptionResource, "DescriptionResource is NULL or empty. Skipping.");
-                }
-
-            }
-            else
-            {
-                TraceService.Critical((int)LogEventId.ModelProvisionCoreCall,
-                      "CSOM runtime doesn't have Web.TitleResource and Web.DescriptionResource() methods support. Skipping validation.");
-
-                assert.SkipProperty(m => m.TitleResource, "TitleResource is null or empty. Skipping.");
-                assert.SkipProperty(m => m.DescriptionResource, "DescriptionResource is null or empty. Skipping.");
+                typedFieldAssert.SkipProperty(m => m.PrimaryLookupFieldTitle, "PrimaryLookupFieldInternalName is NULL. Skipping.");
             }
         }
     }

--- a/SPMeta2/SPMeta2.Regression.Tests/Impl/Scenarios/Fields/DependentLookupFieldScenariousTest.cs
+++ b/SPMeta2/SPMeta2.Regression.Tests/Impl/Scenarios/Fields/DependentLookupFieldScenariousTest.cs
@@ -63,6 +63,7 @@ namespace SPMeta2.Regression.Tests.Impl.Scenarios.Fields
                 {
                     def.LookupField = BuiltInInternalFieldNames.ID;
                     def.PrimaryLookupFieldId = lookupField.Id;
+                    def.AllowMultipleValues = lookupField.AllowMultipleValues;
                 });
 
             var dependentTitleLookupField = ModelGeneratorService.GetRandomDefinition<DependentLookupFieldDefinition>(
@@ -70,6 +71,7 @@ namespace SPMeta2.Regression.Tests.Impl.Scenarios.Fields
                 {
                     def.LookupField = BuiltInInternalFieldNames.Title;
                     def.PrimaryLookupFieldId = lookupField.Id;
+                    def.AllowMultipleValues = lookupField.AllowMultipleValues;
                 });
 
             var masterList = ModelGeneratorService.GetRandomDefinition<ListDefinition>();
@@ -168,6 +170,11 @@ namespace SPMeta2.Regression.Tests.Impl.Scenarios.Fields
                 {
                     def.LookupField = BuiltInInternalFieldNames.ID;
                     def.PrimaryLookupFieldId = lookupField.Id;
+                    def.LookupWebId = lookupField.LookupWebId;
+                    def.LookupWebUrl = lookupField.LookupWebUrl;
+                    def.LookupList = lookupField.LookupList;
+                    def.LookupListTitle = lookupField.LookupListTitle;
+                    def.LookupListUrl = lookupField.LookupListUrl;
                 });
 
             var dependentTitleLookupField = ModelGeneratorService.GetRandomDefinition<DependentLookupFieldDefinition>(
@@ -175,6 +182,11 @@ namespace SPMeta2.Regression.Tests.Impl.Scenarios.Fields
                 {
                     def.LookupField = BuiltInInternalFieldNames.Title;
                     def.PrimaryLookupFieldId = lookupField.Id;
+                    def.LookupWebId = lookupField.LookupWebId;
+                    def.LookupWebUrl = lookupField.LookupWebUrl;
+                    def.LookupList = lookupField.LookupList;
+                    def.LookupListTitle = lookupField.LookupListTitle;
+                    def.LookupListUrl = lookupField.LookupListUrl;
                 });
 
             var masterList = ModelGeneratorService.GetRandomDefinition<ListDefinition>();
@@ -465,7 +477,87 @@ namespace SPMeta2.Regression.Tests.Impl.Scenarios.Fields
         [TestCategory("Regression.Scenarios.Fields.DependentLookupField.Scope")]
         public void CanDeploy_DependentLookupField_OnList()
         {
-            throw new SPMeta2NotImplementedException("");
+            var masterList = ModelGeneratorService.GetRandomDefinition<ListDefinition>();
+            var childList = ModelGeneratorService.GetRandomDefinition<ListDefinition>();
+
+            var lookupField = ModelGeneratorService.GetRandomDefinition<LookupFieldDefinition>(def =>
+            {
+                def.ShowInNewForm = true;
+                def.ShowInDisplayForm = true;
+                def.ShowInEditForm = true;
+                def.ShowInListSettings = true;
+                def.ShowInViewForms = true;
+
+                def.Hidden = false;
+                def.Required = false;
+                def.AllowMultipleValues = false;
+
+                #pragma warning disable 618
+                def.LookupListUrl = masterList.GetListUrl();
+                #pragma warning restore 618
+            });
+
+            var dependentIdLookupField = ModelGeneratorService.GetRandomDefinition<DependentLookupFieldDefinition>(
+                def =>
+                {
+                    def.LookupField = BuiltInInternalFieldNames.ID;
+                    def.PrimaryLookupFieldId = lookupField.Id;
+                });
+
+            var dependentTitleLookupField = ModelGeneratorService.GetRandomDefinition<DependentLookupFieldDefinition>(
+                def =>
+                {
+                    def.LookupField = BuiltInInternalFieldNames.Title;
+                    def.PrimaryLookupFieldId = lookupField.Id;
+                });
+
+            var webModel = SPMeta2Model.NewWebModel(web =>
+            {
+                web.AddList(masterList, list =>
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        list.AddListItem(new ListItemDefinition
+                        {
+                            Title = string.Format("master item {0} - {1}", i, Rnd.String())
+                        });
+                    }
+                });
+
+                web.AddList(childList, list =>
+                {
+                    list.AddField(lookupField);
+                });
+            });
+
+            TestModel(webModel);
+
+            // add dep field
+            var depWebModel = SPMeta2Model.NewWebModel(web =>
+            {
+                web.AddList(childList, list =>
+                {
+                    list.AddField(dependentIdLookupField);
+                    list.AddField(dependentTitleLookupField);
+
+                    list.AddListView(new ListViewDefinition
+                    {
+                        Title = "Test View",
+                        Fields = new Collection<string>
+                        {
+                            BuiltInInternalFieldNames.Edit,
+                            BuiltInInternalFieldNames.ID,
+                            BuiltInInternalFieldNames.Title,
+                            lookupField.InternalName,
+                            dependentIdLookupField.InternalName,
+                            dependentTitleLookupField.InternalName
+                        },
+                        IsDefault = true
+                    });
+                });
+            });
+
+            TestModel(depWebModel);
         }
 
         #endregion

--- a/SPMeta2/SPMeta2.SSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
+++ b/SPMeta2/SPMeta2.SSOM/ModelHandlers/Fields/DependentLookupFieldModelHandler.cs
@@ -1,18 +1,15 @@
 ﻿using System;
-using System.Linq;
 using System.Xml.Linq;
 using Microsoft.SharePoint;
-using SPMeta2.Common;
 using SPMeta2.Definitions;
 using SPMeta2.Definitions.Fields;
 using SPMeta2.Enumerations;
-using SPMeta2.SSOM.ModelHosts;
 using SPMeta2.Utils;
 using SPMeta2.Exceptions;
 
 namespace SPMeta2.SSOM.ModelHandlers.Fields
 {
-    public class DependentLookupFieldModelHandler : SSOMModelHandlerBase
+    public class DependentLookupFieldModelHandler : LookupFieldModelHandler
     {
         #region properties
 
@@ -20,173 +17,51 @@ namespace SPMeta2.SSOM.ModelHandlers.Fields
         {
             get { return typeof(DependentLookupFieldDefinition); }
         }
+
         #endregion
 
         #region methods
 
-        public override void DeployModel(object modelHost, DefinitionBase model)
+        protected override void ProcessFieldProperties(SPField field, FieldDefinition fieldModel)
         {
-            var definition = model.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            // let base setting be setup
+            base.ProcessFieldProperties(field, fieldModel);
 
-            if (modelHost is SiteModelHost)
-                DeploySiteDependentLookup(modelHost, modelHost as SiteModelHost, definition);
-            else if (modelHost is WebModelHost)
-                DeployWebDependentLookup(modelHost, modelHost as WebModelHost, definition);
-            else if (modelHost is ListModelHost)
-                DeployListDependentLookup(modelHost, modelHost as ListModelHost, definition);
+            var typedField = field as SPFieldLookup;
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+
+            var primaryLookupField = GetPrimaryField(typedFieldModel);
+
+            typedField.LookupList = primaryLookupField.LookupList;
+            typedField.LookupWebId = primaryLookupField.LookupWebId;
+            typedField.ReadOnlyField = true;
+            typedField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
+            typedField.Direction = primaryLookupField.Direction;
+            typedField.LookupField = typedFieldModel.LookupField;
         }
-
-        private void DeployListDependentLookup(object modelHost, ListModelHost listModelHost, DependentLookupFieldDefinition definition)
+        
+        protected override void ProcessSPFieldXElement(XElement fieldTemplate, FieldDefinition fieldModel)
         {
-            DeployDependentLookupField(modelHost, listModelHost.HostList.Fields, definition);
-        }
+            base.ProcessSPFieldXElement(fieldTemplate, fieldModel);
 
-        private void DeployWebDependentLookup(object modelHost, WebModelHost webModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, webModelHost.HostWeb.Fields, definition);
-        }
+            var typedFieldModel = fieldModel.WithAssertAndCast<DependentLookupFieldDefinition>("model", value => value.RequireNotNull());
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.Mult, typedFieldModel.AllowMultipleValues.ToString().ToUpper());
 
-        private void DeploySiteDependentLookup(object modelHost, SiteModelHost siteModelHost, DependentLookupFieldDefinition definition)
-        {
-            DeployDependentLookupField(modelHost, siteModelHost.HostSite.RootWeb.Fields, definition);
-        }
-
-        protected virtual SPFieldLookup GetField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetDependentLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetDependentLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetDependentLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        protected virtual SPFieldLookup GetPrimaryField(object modelHost, DependentLookupFieldDefinition definition)
-        {
-            if (modelHost is SiteModelHost)
-                return GetPrimaryLookupField((modelHost as SiteModelHost).HostSite.RootWeb.Fields, definition);
-            else if (modelHost is WebModelHost)
-                return GetPrimaryLookupField((modelHost as WebModelHost).HostWeb.Fields, definition);
-            else if (modelHost is ListModelHost)
-                return GetPrimaryLookupField((modelHost as ListModelHost).HostList.Fields, definition);
-
-            throw new SPMeta2Exception("Unsupported model host");
-        }
-
-        private void DeployDependentLookupField(object modelHost, SPFieldCollection fields, DependentLookupFieldDefinition definition)
-        {
-            var primaryLookupField = GetPrimaryLookupField(fields, definition);
-            var dependentLookupField = GetDependentLookupField(fields, definition);
-
-            if (dependentLookupField == null)
+            SPField primaryField = GetPrimaryField(typedFieldModel);
+            if (primaryField == null)
             {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = null,
-                    ObjectType = typeof(SPFieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
-                var internalName = fields.AddDependentLookup(definition.InternalName, primaryLookupField.Id);
-
-                //dependentLookupField = (SPFieldLookup)fields.CreateNewField(SPFieldType.Lookup.ToString(), definition.InternalName);
-
-                dependentLookupField = GetDependentLookupField(fields, definition);
-                dependentLookupField.Title = definition.Title;
-
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
-                dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
-
-                if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
-                {
-                    dependentLookupField.LookupList = primaryLookupField.LookupList;
-                }
-
-                if (string.IsNullOrEmpty(dependentLookupField.PrimaryFieldId))
-                    dependentLookupField.PrimaryFieldId = primaryLookupField.Id.ToString();
-
-                dependentLookupField.ReadOnlyField = true;
-                dependentLookupField.AllowMultipleValues = primaryLookupField.AllowMultipleValues;
-                dependentLookupField.UnlimitedLengthInDocumentLibrary = primaryLookupField.UnlimitedLengthInDocumentLibrary;
-                dependentLookupField.Direction = primaryLookupField.Direction;
-
-                //dependentLookupField.Update(true);
-                //dependentLookupField = GetDependentLookupField(fields, definition);
-            }
-            else
-            {
-                InvokeOnModelEvent(this, new ModelEventArgs
-                {
-                    CurrentModelNode = null,
-                    Model = null,
-                    EventType = ModelEventType.OnProvisioning,
-                    Object = dependentLookupField,
-                    ObjectType = typeof(SPFieldLookup),
-                    ObjectDefinition = definition,
-                    ModelHost = modelHost
-                });
-
+                throw new SPMeta2Exception("PrimaryLookupField needs to be defined when creating a DependentLookupField");
             }
 
-            dependentLookupField.Title = definition.Title;
-
-            dependentLookupField.LookupField = definition.LookupField;
-
-            if (!string.IsNullOrEmpty(primaryLookupField.LookupList) &&
-                string.IsNullOrEmpty(dependentLookupField.LookupList))
-            {
-                dependentLookupField.LookupList = primaryLookupField.LookupList;
-            }
-            dependentLookupField.LookupWebId = primaryLookupField.LookupWebId;
-
-            dependentLookupField.Group = definition.Group ?? string.Empty;
-            dependentLookupField.Description = definition.Description ?? string.Empty;
-
-            InvokeOnModelEvent(this, new ModelEventArgs
-            {
-                CurrentModelNode = null,
-                Model = null,
-                EventType = ModelEventType.OnProvisioned,
-                Object = dependentLookupField,
-                ObjectType = typeof(SPFieldLookup),
-                ObjectDefinition = definition,
-                ModelHost = modelHost
-            });
-
-            if (fields.List != null)
-                dependentLookupField.Update();
-            else
-                dependentLookupField.Update(true);
+            fieldTemplate.SetAttribute(BuiltInFieldAttributes.FieldReference, primaryField.Id.ToString("B"));
         }
 
-        protected virtual SPFieldLookup GetDependentLookupField(SPFieldCollection fields, DependentLookupFieldDefinition definition)
+        protected virtual SPFieldLookup GetPrimaryField(DependentLookupFieldDefinition definition)
         {
-            var targetName = definition.InternalName.ToUpper();
+            var fields = FieldLookupService.GetFieldCollection(this.ModelHost);
 
-            return fields
-                     .OfType<SPField>()
-                     .FirstOrDefault(f => f.InternalName.ToUpper() == targetName) as SPFieldLookup;
-        }
-
-        protected virtual SPFieldLookup GetPrimaryLookupField(SPFieldCollection fields, DependentLookupFieldDefinition definition)
-        {
-            if (definition.PrimaryLookupFieldId.HasGuidValue())
-                return fields[definition.PrimaryLookupFieldId.Value] as SPFieldLookup;
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldInternalName))
-                return fields.GetFieldByInternalName(definition.PrimaryLookupFieldInternalName) as SPFieldLookup; ;
-
-            if (!string.IsNullOrEmpty(definition.PrimaryLookupFieldTitle))
-                return fields.GetField(definition.PrimaryLookupFieldTitle) as SPFieldLookup; ;
-
-            throw new SPMeta2Exception("PrimaryLookupFieldTitle / PrimaryLookupFieldInternalName / PrimaryLookupFieldId need to be defined");
+            return FieldLookupService.GetFieldAs<SPFieldLookup>(
+                fields, definition.PrimaryLookupFieldId, definition.PrimaryLookupFieldInternalName, definition.PrimaryLookupFieldTitle);
         }
 
         #endregion

--- a/SPMeta2/SPMeta2/Definitions/Fields/DependentLookupFieldDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/Fields/DependentLookupFieldDefinition.cs
@@ -20,10 +20,17 @@ namespace SPMeta2.Definitions.Fields
     [Serializable]
     [DataContract]
     [ExpectArrayExtensionMethod]
-    [ExpectManyInstances]
 
+    [ExpectManyInstances]
     public class DependentLookupFieldDefinition : LookupFieldDefinition
     {
+        #region constructors
+
+        public DependentLookupFieldDefinition() : base()
+        {
+        }
+
+        #endregion
         #region properties
 
         /// <summary>
@@ -31,7 +38,7 @@ namespace SPMeta2.Definitions.Fields
         /// </summary>
         /// 
         [ExpectValidation]
-        //[ExpectRequired]
+        [ExpectRequired]
         [DataMember]
         [IdentityKey]
         public override Guid Id { get; set; }
@@ -74,6 +81,8 @@ namespace SPMeta2.Definitions.Fields
             return new ToStringResult<DependentLookupFieldDefinition>(this, base.ToString())
                           .AddPropertyValue(p => p.Title)
                           .AddPropertyValue(p => p.InternalName)
+                          .AddPropertyValue(p => p.PrimaryLookupFieldId)
+                          .AddPropertyValue(p => p.AllowMultipleValues)
                           .ToString();
         }
     }

--- a/SPMeta2/SPMeta2/Enumerations/BuiltInFieldAttributes.cs
+++ b/SPMeta2/SPMeta2/Enumerations/BuiltInFieldAttributes.cs
@@ -83,6 +83,8 @@ namespace SPMeta2.Enumerations
 
         public static string Format = "Format";
 
+        public static string FieldReference = "FieldRef";
+
         #endregion
     }
 }


### PR DESCRIPTION
Fix for #807:
- Rewrote DependentLookupFieldHandler to have control over which ID and InternalName will be used
- Minor refactoring regarding field lookups
- Implemented Test "CanDeploy_DependentLookupField_OnList"
- Could not get "CanDeployRandom_DependentLookupFieldDefinition" to pass in CSOM, can you have a look?