### PR TITLE
IncludeRootFolder property for ListView has been added

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/ListViewModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/ListViewModelHandler.cs
@@ -243,6 +243,7 @@ namespace SPMeta2.CSOM.ModelHandlers
 
             listView.DefaultView = definition.IsDefault;
             listView.Paged = definition.IsPaged;
+            listView.IncludeRootFolder = definition.IncludeRootFolder;
 
             if (!string.IsNullOrEmpty(definition.Query))
                 listView.ViewQuery = definition.Query;

--- a/SPMeta2/SPMeta2/Definitions/ListViewDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/ListViewDefinition.cs
@@ -154,6 +154,15 @@ namespace SPMeta2.Definitions
         [DataMember]
         public bool IsDefault { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether the list view should include parent folder item.
+        /// </summary>
+        /// 
+        [ExpectValidation]
+        [ExpectUpdate]
+        [DataMember]
+        public bool IncludeRootFolder { get; set; }
+
         [ExpectValidation]
         [ExpectUpdate]
         [DataMember]


### PR DESCRIPTION
"IncludeRootFolder" property support was added. This is default SharePoint CSOM property of ListView. It provides showing parent folder item in list view.