### PR TITLE
fixed ListItemAllFields error for WebPart Pages not in lists

### DIFF
--- a/SPMeta2/SPMeta2.CSOM/ModelHandlers/ModuleFileModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM/ModelHandlers/ModuleFileModelHandler.cs
@@ -327,7 +327,13 @@ namespace SPMeta2.CSOM.ModelHandlers
             if (file != null)
             {
                 context.Load(file, f => f.Exists);
+                context.Load(file, f => f.ListItemAllFields); //SergeiSnitko. Need to be loaded to get if object is null
                 context.ExecuteQueryWithTrace();
+                //SergeiSnitko. I don't know all logic based on doesFileHasListItem. So I fill doesFileHasListItem by the real value
+                //of ListItem existing only if doesFileHasListItem is true. This action helps to prevent exceptions on web part provision
+                //on the page without ListItem not only under Forms folder (for example Forms/ContentTypeName/videoplayerpage.aspx fires exception)
+                doesFileHasListItem = doesFileHasListItem ? !(bool)file.ListItemAllFields.ServerObjectIsNull : doesFileHasListItem;
+
 
                 if (file.Exists)
                 {


### PR DESCRIPTION
I had an error on web part provision
on the page without ListItem not only under Forms folder (for example Forms/ContentTypeName/videoplayerpage.aspx fires exception) like this
![screenshot_9](https://cloud.githubusercontent.com/assets/7835251/24194889/c6536814-0f08-11e7-9bfa-9f4992014c23.png)

I've made some fix and it worked for me. Now I can add web parts on pages in every folder.

Check it, please. I can missunderstand something and crash some logic =)