### PR TITLE
Extending ResultScriptWebPartDefinition, Handler, Validator

### DIFF
--- a/SPMeta2/SPMeta2.Containers.Standard/DefinitionGenerators/Webparts/ResultScriptWebPartDefinitionGenerator.cs
+++ b/SPMeta2/SPMeta2.Containers.Standard/DefinitionGenerators/Webparts/ResultScriptWebPartDefinitionGenerator.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using SPMeta2.Definitions;
 using SPMeta2.Standard.Definitions.Webparts;
@@ -20,6 +17,8 @@ namespace SPMeta2.Containers.Standard.DefinitionGenerators.Webparts
 
                 def.ZoneId = "FullPage";
                 def.ZoneIndex = Rnd.Int(100);
+
+                def.EmptyMessage = Rnd.String();
             });
         }
     }

--- a/SPMeta2/SPMeta2.Regression.SSOM.Standard/Validation/Webparts/ResultScriptWebPartDefinitionValidator.cs
+++ b/SPMeta2/SPMeta2.Regression.SSOM.Standard/Validation/Webparts/ResultScriptWebPartDefinitionValidator.cs
@@ -48,19 +48,145 @@ namespace SPMeta2.Regression.SSOM.Standard.Validation.Webparts
                     assert.SkipProperty(m => m.DataProviderJSON, "DataProviderJSON is null or empty, skipping.");
 
                 if (!string.IsNullOrEmpty(definition.EmptyMessage))
-                    throw new NotImplementedException();
+                    assert.ShouldBeEqual(m => m.EmptyMessage, o => o.EmptyMessage);
                 else
                     assert.SkipProperty(m => m.EmptyMessage, "EmptyMessage is null or empty, skipping.");
 
                 if (definition.ResultsPerPage.HasValue)
-                    throw new NotImplementedException();
+                    assert.ShouldBeEqual(m => m.ResultsPerPage.Value, o => o.ResultsPerPage);
                 else
                     assert.SkipProperty(m => m.ResultsPerPage, "ResultsPerPage is null or empty, skipping.");
 
                 if (definition.ShowResultCount.HasValue)
-                    throw new NotImplementedException();
+                    assert.ShouldBeEqual(m => m.ShowResultCount.Value, o => o.ShowResultCount);
                 else
                     assert.SkipProperty(m => m.ShowResultCount, "ShowResultCount is null or empty, skipping.");
+
+                if (definition.ShowLanguageOptions.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowLanguageOptions.Value, o => o.ShowLanguageOptions);
+                else
+                    assert.SkipProperty(m => m.ShowLanguageOptions, "ShowLanguageOptions is null or empty, skipping.");
+
+                if (definition.MaxPagesBeforeCurrent.HasValue)
+                    assert.ShouldBeEqual(m => m.MaxPagesBeforeCurrent.Value, o => o.MaxPagesBeforeCurrent);
+                else
+                    assert.SkipProperty(m => m.MaxPagesBeforeCurrent, "MaxPagesBeforeCurrent is null or empty, skipping.");
+
+                if (definition.ShowBestBets.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowBestBets.Value, o => o.ShowBestBets);
+                else
+                    assert.SkipProperty(m => m.ShowBestBets, "ShowBestBets is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.AdvancedSearchPageAddress))
+                    assert.ShouldBeEqual(m => m.AdvancedSearchPageAddress, o => o.AdvancedSearchPageAddress);
+                else
+                    assert.SkipProperty(m => m.AdvancedSearchPageAddress, "AdvancedSearchPageAddress is null or empty, skipping.");
+
+                if (definition.UseSharedDataProvider.HasValue)
+                    assert.ShouldBeEqual(m => m.UseSharedDataProvider.Value, o => o.UseSharedDataProvider);
+                else
+                    assert.SkipProperty(m => m.UseSharedDataProvider, "UseSharedDataProvider is null or empty, skipping.");
+
+                if (definition.ShowPreferencesLink.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowPreferencesLink.Value, o => o.ShowPreferencesLink);
+                else
+                    assert.SkipProperty(m => m.ShowPreferencesLink, "ShowPreferencesLink is null or empty, skipping.");
+
+                if (definition.ShowViewDuplicates.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowViewDuplicates.Value, o => o.ShowViewDuplicates);
+                else
+                    assert.SkipProperty(m => m.ShowViewDuplicates, "ShowViewDuplicates is null or empty, skipping.");
+
+                if (definition.RepositionLanguageDropDown.HasValue)
+                    assert.ShouldBeEqual(m => m.RepositionLanguageDropDown.Value, o => o.RepositionLanguageDropDown);
+                else
+                    assert.SkipProperty(m => m.RepositionLanguageDropDown, "RepositionLanguageDropDown is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.PreloadedItemTemplateIdsJson))
+                    throw new NotImplementedException();
+                else
+                    assert.SkipProperty(m => m.PreloadedItemTemplateIdsJson, "PreloadedItemTemplateIdsJson is null or empty, skipping.");
+
+                if (definition.ShowPaging.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowPaging.Value, o => o.ShowPaging);
+                else
+                    assert.SkipProperty(m => m.ShowPaging, "ShowPaging is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.ResultTypeId))
+                    assert.ShouldBeEqual(m => m.ResultTypeId, o => o.ResultTypeId);
+                else
+                    assert.SkipProperty(m => m.ResultTypeId, "ResultTypeId is null or empty, skipping.");
+
+                if (definition.ShowResults.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowResults.Value, o => o.ShowResults);
+                else
+                    assert.SkipProperty(m => m.ShowResults, "ShowResults is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.ItemTemplateId))
+                    assert.ShouldBeEqual(m => m.ItemTemplateId, o => o.ItemTemplateId);
+                else
+                    assert.SkipProperty(m => m.ItemTemplateId, "ItemTemplateId is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.ItemBodyTemplateId))
+                    assert.ShouldBeEqual(m => m.ItemBodyTemplateId, o => o.ItemBodyTemplateId);
+                else
+                    assert.SkipProperty(m => m.ItemBodyTemplateId, "ItemBodyTemplateId is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.HitHighlightedPropertiesJson))
+                    throw new NotImplementedException();
+                else
+                    assert.SkipProperty(m => m.HitHighlightedPropertiesJson, "HitHighlightedPropertiesJson is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.AvailableSortsJson))
+                    throw new NotImplementedException();
+                else
+                    assert.SkipProperty(m => m.AvailableSortsJson, "AvailableSortsJson is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.RenderTemplateId))
+                    assert.ShouldBeEqual(m => m.RenderTemplateId, o => o.RenderTemplateId);
+                else
+                    assert.SkipProperty(m => m.RenderTemplateId, "RenderTemplateId is null or empty, skipping.");
+
+                if (definition.ShowPersonalFavorites.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowPersonalFavorites.Value, o => o.ShowPersonalFavorites);
+                else
+                    assert.SkipProperty(m => m.ShowPersonalFavorites, "ShowPersonalFavorites is null or empty, skipping.");
+
+                if (definition.ShowSortOptions.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowSortOptions.Value, o => o.ShowSortOptions);
+                else
+                    assert.SkipProperty(m => m.ShowSortOptions, "ShowSortOptions is null or empty, skipping.");
+
+                if (definition.ShowAlertMe.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowAlertMe.Value, o => o.ShowAlertMe);
+                else
+                    assert.SkipProperty(m => m.ShowAlertMe, "ShowAlertMe is null or empty, skipping.");
+
+                if (definition.ShowDidYouMean.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowDidYouMean.Value, o => o.ShowDidYouMean);
+                else
+                    assert.SkipProperty(m => m.ShowDidYouMean, "ShowDidYouMean is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.QueryGroupName))
+                    assert.ShouldBeEqual(m => m.QueryGroupName, o => o.QueryGroupName);
+                else
+                    assert.SkipProperty(m => m.QueryGroupName, "QueryGroupName is null or empty, skipping.");
+
+                if (definition.ShowAdvancedLink.HasValue)
+                    assert.ShouldBeEqual(m => m.ShowAdvancedLink.Value, o => o.ShowAdvancedLink);
+                else
+                    assert.SkipProperty(m => m.ShowAdvancedLink, "ShowAdvancedLink is null or empty, skipping.");
+
+                if (definition.BypassResultTypes.HasValue)
+                    assert.ShouldBeEqual(m => m.BypassResultTypes.Value, o => o.BypassResultTypes);
+                else
+                    assert.SkipProperty(m => m.BypassResultTypes, "BypassResultTypes is null or empty, skipping.");
+
+                if (!string.IsNullOrEmpty(definition.GroupTemplateId))
+                    assert.ShouldBeEqual(m => m.GroupTemplateId, o => o.GroupTemplateId);
+                else
+                    assert.SkipProperty(m => m.GroupTemplateId, "GroupTemplateId is null or empty, skipping.");
+
             });
         }
 

--- a/SPMeta2/SPMeta2.SSOM.Standard/ModelHandlers/Webparts/ResultScriptWebPartModelHandler.cs
+++ b/SPMeta2/SPMeta2.SSOM.Standard/ModelHandlers/Webparts/ResultScriptWebPartModelHandler.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 using System.Web.UI.WebControls.WebParts;
 using Microsoft.Office.Server.Search.WebControls;
-using Microsoft.SharePoint.Portal.WebControls;
 using SPMeta2.Definitions;
 using SPMeta2.SSOM.ModelHandlers;
 using SPMeta2.SSOM.ModelHosts;
@@ -51,6 +46,78 @@ namespace SPMeta2.SSOM.Standard.ModelHandlers.Webparts
 
             if (definition.ShowResultCount.HasValue)
                 typedWebpart.ShowResultCount = definition.ShowResultCount.Value;
+
+            if (definition.ShowLanguageOptions.HasValue)
+                typedWebpart.ShowLanguageOptions = definition.ShowLanguageOptions.Value;
+
+            if (definition.MaxPagesBeforeCurrent.HasValue)
+                typedWebpart.MaxPagesBeforeCurrent = definition.MaxPagesBeforeCurrent.Value;
+
+            if (definition.ShowBestBets.HasValue)
+                typedWebpart.ShowBestBets = definition.ShowBestBets.Value;
+
+            if (!string.IsNullOrEmpty(definition.AdvancedSearchPageAddress))
+                typedWebpart.AdvancedSearchPageAddress = definition.AdvancedSearchPageAddress;
+
+            if (definition.UseSharedDataProvider.HasValue)
+                typedWebpart.UseSharedDataProvider = definition.UseSharedDataProvider.Value;
+
+            if (definition.ShowPreferencesLink.HasValue)
+                typedWebpart.ShowPreferencesLink = definition.ShowPreferencesLink.Value;
+
+            if (definition.ShowViewDuplicates.HasValue)
+                typedWebpart.ShowViewDuplicates = definition.ShowViewDuplicates.Value;
+
+            if (definition.RepositionLanguageDropDown.HasValue)
+                typedWebpart.RepositionLanguageDropDown = definition.RepositionLanguageDropDown.Value;
+
+            if (!string.IsNullOrEmpty(definition.PreloadedItemTemplateIdsJson))
+                typedWebpart.PreloadedItemTemplateIdsJson = definition.PreloadedItemTemplateIdsJson;
+
+            if (definition.ShowPaging.HasValue)
+                typedWebpart.ShowPaging = definition.ShowPaging.Value;
+
+            if (!string.IsNullOrEmpty(definition.ResultTypeId))
+                typedWebpart.ResultTypeId = definition.ResultTypeId;
+
+            if (definition.ShowResults.HasValue)
+                typedWebpart.ShowResults = definition.ShowResults.Value;
+
+            if (!string.IsNullOrEmpty(definition.ItemTemplateId))
+                typedWebpart.ItemTemplateId = definition.ItemTemplateId;
+
+            if (!string.IsNullOrEmpty(definition.HitHighlightedPropertiesJson))
+                typedWebpart.HitHighlightedPropertiesJson = definition.HitHighlightedPropertiesJson;
+
+            if (!string.IsNullOrEmpty(definition.AvailableSortsJson))
+                typedWebpart.AvailableSortsJson = definition.AvailableSortsJson;
+
+            if (!string.IsNullOrEmpty(definition.RenderTemplateId))
+                typedWebpart.RenderTemplateId = definition.RenderTemplateId;
+
+            if (definition.ShowPersonalFavorites.HasValue)
+                typedWebpart.ShowPersonalFavorites = definition.ShowPersonalFavorites.Value;
+
+            if (definition.ShowSortOptions.HasValue)
+                typedWebpart.ShowSortOptions = definition.ShowSortOptions.Value;
+
+            if (definition.ShowAlertMe.HasValue)
+                typedWebpart.ShowAlertMe = definition.ShowAlertMe.Value;
+
+            if (definition.ShowDidYouMean.HasValue)
+                typedWebpart.ShowDidYouMean = definition.ShowDidYouMean.Value;
+
+            if (!string.IsNullOrEmpty(definition.QueryGroupName))
+                typedWebpart.QueryGroupName = definition.QueryGroupName;
+
+            if (definition.ShowAdvancedLink.HasValue)
+                typedWebpart.ShowAdvancedLink = definition.ShowAdvancedLink.Value;
+
+            if (definition.BypassResultTypes.HasValue)
+                typedWebpart.BypassResultTypes = definition.BypassResultTypes.Value;
+
+            if (!string.IsNullOrEmpty(definition.GroupTemplateId))
+                typedWebpart.GroupTemplateId = definition.GroupTemplateId;
         }
 
         #endregion

--- a/SPMeta2/SPMeta2.Standard/Definitions/Webparts/ResultScriptWebPartDefinition.cs
+++ b/SPMeta2/SPMeta2.Standard/Definitions/Webparts/ResultScriptWebPartDefinition.cs
@@ -48,7 +48,105 @@ namespace SPMeta2.Standard.Definitions.Webparts
         [ExpectValidation]
         public bool? ShowResultCount { get; set; }
 
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowLanguageOptions { get; set; }
+        
+        [DataMember]
+        [ExpectValidation]
+        public int? MaxPagesBeforeCurrent { get; set; }
 
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowBestBets { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string AdvancedSearchPageAddress { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? UseSharedDataProvider { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPreferencesLink { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowViewDuplicates { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? RepositionLanguageDropDown { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string PreloadedItemTemplateIdsJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPaging { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ResultTypeId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowResults { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ItemTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ItemBodyTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string HitHighlightedPropertiesJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string AvailableSortsJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string RenderTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPersonalFavorites { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowSortOptions { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowAlertMe { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowDidYouMean { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string QueryGroupName { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowAdvancedLink { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? BypassResultTypes { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string GroupTemplateId { get; set; }
         #endregion
 
         #region methods


### PR DESCRIPTION
Hey,

I've asked a colleague to go ahead and extend ResultScriptWebpartDefinition, handler and validator to our needs. I understand that there's a lot more work to do regarding generator and validating json property but I have hope you've done this before and can point out some classes for reference.

ResultScriptWebpart uses a lot of properties which are defined by JSON and I would like to have a class representing those properties inside the json. Since DataProviderJSONDefinition doesn't seem to be a good idea, I was wondering if you think such a class should be part of SPMeta at all.

Looking forward to discuss those changes with you and we're planning on enhancing them further down the road.