### PR TITLE
Extended ResultScriptWebpart Definition, ModelHandler for CSOM.

### DIFF
--- a/SPMeta2/SPMeta2.CSOM.Standard/ModelHandlers/Webparts/ResultScriptWebPartModelHandler.cs
+++ b/SPMeta2/SPMeta2.CSOM.Standard/ModelHandlers/Webparts/ResultScriptWebPartModelHandler.cs
@@ -28,13 +28,118 @@ namespace SPMeta2.CSOM.Standard.ModelHandlers.Webparts
 
         protected override string GetWebpartXmlDefinition(ListItemModelHost listItemModelHost, WebPartDefinitionBase webPartModel)
         {
-            var wpModel = webPartModel.WithAssertAndCast<ResultScriptWebPartDefinition>("model", value => value.RequireNotNull());
-          
-            var wpXml = WebpartXmlExtensions
-                .LoadWebpartXmlDocument(BuiltInWebPartTemplates.ResultScriptWebPart)
-                .ToString();
+            var definition = webPartModel.WithAssertAndCast<ResultScriptWebPartDefinition>("model", value => value.RequireNotNull());
+            var xml = WebpartXmlExtensions.LoadWebpartXmlDocument(ProcessCommonWebpartProperties(BuiltInWebPartTemplates.ResultScriptWebPart, webPartModel));
+            
+            if (!string.IsNullOrEmpty(definition.DataProviderJSON))
+                xml.SetOrUpdateProperty("DataProviderJSON", definition.DataProviderJSON);
 
-            return wpXml;
+            if (!string.IsNullOrEmpty(definition.EmptyMessage))
+                xml.SetOrUpdateProperty("EmptyMessage", definition.EmptyMessage);
+
+            if (definition.ResultsPerPage.HasValue)
+                xml.SetOrUpdateProperty("ResultsPerPage", definition.ResultsPerPage.Value.ToString());
+
+            if (definition.ShowResultCount.HasValue)
+                xml.SetOrUpdateProperty("ShowResultCount", definition.ShowResultCount.Value.ToString());
+
+            if (definition.MaxPagesBeforeCurrent.HasValue)
+                xml.SetOrUpdateProperty("MaxPagesBeforeCurrent", definition.MaxPagesBeforeCurrent.Value.ToString());
+
+            if (definition.ShowBestBets.HasValue)
+                xml.SetOrUpdateProperty("ShowBestBets", definition.ShowBestBets.Value.ToString());
+
+            if (definition.ShowViewDuplicates.HasValue)
+                xml.SetOrUpdateProperty("ShowViewDuplicates", definition.ShowViewDuplicates.Value.ToString());
+
+            if (definition.Height.HasValue)
+                xml.SetOrUpdateProperty("Height", definition.Height.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.AdvancedSearchPageAddress))
+                xml.SetOrUpdateProperty("AdvancedSearchPageAddress", definition.AdvancedSearchPageAddress);
+
+            if (definition.UseSharedDataProvider.HasValue)
+                xml.SetOrUpdateProperty("UseSharedDataProvider", definition.UseSharedDataProvider.Value.ToString());
+
+            if (definition.ShowPreferencesLink.HasValue)
+                xml.SetOrUpdateProperty("ShowPreferencesLink", definition.ShowPreferencesLink.Value.ToString());
+
+            if (definition.RepositionLanguageDropDown.HasValue)
+                xml.SetOrUpdateProperty("RepositionLanguageDropDown", definition.RepositionLanguageDropDown.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.PreloadedItemTemplateIdsJson))
+                xml.SetOrUpdateProperty("PreloadedItemTemplateIdsJson", definition.PreloadedItemTemplateIdsJson);
+
+            if (definition.ShowPaging.HasValue)
+                xml.SetOrUpdateProperty("ShowPaging", definition.ShowPaging.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.ResultTypeId))
+                xml.SetOrUpdateProperty("ResultTypeId", definition.ResultTypeId);
+
+            if (!string.IsNullOrEmpty(definition.Title))
+                xml.SetOrUpdateProperty("Title", definition.Title);
+
+            if (definition.ShowResults.HasValue)
+                xml.SetOrUpdateProperty("ShowResults", definition.ShowResults.Value.ToString());
+
+            if (definition.Hidden.HasValue)
+                xml.SetOrUpdateProperty("Hidden", definition.Hidden.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.ItemTemplateId))
+                xml.SetOrUpdateProperty("ItemTemplateId", definition.ItemTemplateId);
+
+            if (!string.IsNullOrEmpty(definition.ItemBodyTemplateId))
+                xml.SetOrUpdateProperty("ItemBodyTemplateId", definition.ItemBodyTemplateId);
+
+            if (!string.IsNullOrEmpty(definition.HitHighlightedPropertiesJson))
+                xml.SetOrUpdateProperty("HitHighlightedPropertiesJson", definition.HitHighlightedPropertiesJson);
+
+            if (!string.IsNullOrEmpty(definition.AvailableSortsJson))
+                xml.SetOrUpdateProperty("AvailableSortsJson", definition.AvailableSortsJson);
+
+            if (!string.IsNullOrEmpty(definition.RenderTemplateId))
+                xml.SetOrUpdateProperty("RenderTemplateId", definition.RenderTemplateId);
+
+            if (definition.ShowPersonalFavorites.HasValue)
+                xml.SetOrUpdateProperty("ShowPersonalFavorites", definition.ShowPersonalFavorites.Value.ToString());
+
+            if (definition.ShowSortOptions.HasValue)
+                xml.SetOrUpdateProperty("ShowSortOptions", definition.ShowSortOptions.Value.ToString());
+
+            if (definition.ShowLanguageOptions.HasValue)
+                xml.SetOrUpdateProperty("ShowLanguageOptions", definition.ShowLanguageOptions.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.Description))
+                xml.SetOrUpdateProperty("Description", definition.Description);
+
+            if (!string.IsNullOrEmpty(definition.TitleUrl))
+                xml.SetOrUpdateProperty("TitleUrl", definition.TitleUrl);
+
+            if (definition.ShowAlertMe.HasValue)
+                xml.SetOrUpdateProperty("ShowAlertMe", definition.ShowAlertMe.Value.ToString());
+
+            if (definition.ShowDidYouMean.HasValue)
+                xml.SetOrUpdateProperty("ShowDidYouMean", definition.ShowDidYouMean.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.QueryGroupName))
+                xml.SetOrUpdateProperty("QueryGroupName", definition.QueryGroupName);
+
+            if (definition.Width.HasValue)
+                xml.SetOrUpdateProperty("Width", definition.Width.Value.ToString());
+
+            if (definition.ShowAdvancedLink.HasValue)
+                xml.SetOrUpdateProperty("ShowAdvancedLink", definition.ShowAdvancedLink.Value.ToString());
+
+            if (definition.BypassResultTypes.HasValue)
+                xml.SetOrUpdateProperty("BypassResultTypes", definition.BypassResultTypes.Value.ToString());
+
+            if (!string.IsNullOrEmpty(definition.GroupTemplateId))
+                xml.SetOrUpdateProperty("GroupTemplateId", definition.GroupTemplateId);
+
+            if (!string.IsNullOrEmpty(definition.TitleIconImageUrl))
+                xml.SetOrUpdateProperty("TitleIconImageUrl", definition.TitleIconImageUrl);
+
+            return xml.ToString();
         }
 
         #endregion

--- a/SPMeta2/SPMeta2.Standard/Definitions/Webparts/ResultScriptWebPartDefinition.cs
+++ b/SPMeta2/SPMeta2.Standard/Definitions/Webparts/ResultScriptWebPartDefinition.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 using SPMeta2.Attributes;
 using SPMeta2.Attributes.Regression;
@@ -48,7 +45,105 @@ namespace SPMeta2.Standard.Definitions.Webparts
         [ExpectValidation]
         public bool? ShowResultCount { get; set; }
 
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowLanguageOptions { get; set; }
 
+        [DataMember]
+        [ExpectValidation]
+        public int? MaxPagesBeforeCurrent { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowBestBets { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string AdvancedSearchPageAddress { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? UseSharedDataProvider { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPreferencesLink { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowViewDuplicates { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? RepositionLanguageDropDown { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string PreloadedItemTemplateIdsJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPaging { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ResultTypeId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowResults { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ItemTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string ItemBodyTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string HitHighlightedPropertiesJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string AvailableSortsJson { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string RenderTemplateId { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowPersonalFavorites { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowSortOptions { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowAlertMe { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowDidYouMean { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string QueryGroupName { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? ShowAdvancedLink { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public bool? BypassResultTypes { get; set; }
+
+        [DataMember]
+        [ExpectValidation]
+        public string GroupTemplateId { get; set; }
         #endregion
 
         #region methods
@@ -56,7 +151,7 @@ namespace SPMeta2.Standard.Definitions.Webparts
         public override string ToString()
         {
             return new ToStringResult<ResultScriptWebPartDefinition>(this, base.ToString())
-                          .ToString();
+                .ToString();
         }
 
         #endregion


### PR DESCRIPTION
This doesn't include the Code for the ResultScriptWebPartDefinitionValidator because I wasn´t sure how to implement assertions.

This pr is related to #1057 and if discussion on the other pr continues, there might be some changes to this branch aswell.

Has been tested with SharePoint Standard Server 2016 manually. For automatic testing being available Generators need to be implemeted first, next to some other things most likely.