### PR TITLE
Use AddItem instead of Items.Add to improve performance

### DIFF
--- a/SPMeta2/SPMeta2.SSOM/ModelHandlers/ListItemModelHandler.cs
+++ b/SPMeta2/SPMeta2.SSOM/ModelHandlers/ListItemModelHandler.cs
@@ -104,7 +104,7 @@ namespace SPMeta2.SSOM.ModelHandlers
             {
                 TraceService.Information((int)LogEventId.ModelProvisionProcessingNewObject, "Processing new list item");
 
-                var newItem = list.Items.Add(folder.ServerRelativeUrl, SPFileSystemObjectType.File, null);
+                var newItem = list.AddItem(folder.ServerRelativeUrl, SPFileSystemObjectType.File, null);
 
                 MapListItemProperties(newItem, listItemModel);
 


### PR DESCRIPTION
In large lists Items.Add performs way worse than AddItem and therefor shouldn't be used.