### PR TITLE
Added Owner property to ToString override of SecurityGroupDefinition

### DIFF
--- a/SPMeta2/SPMeta2/Definitions/SecurityGroupDefinition.cs
+++ b/SPMeta2/SPMeta2/Definitions/SecurityGroupDefinition.cs
@@ -130,7 +130,7 @@ namespace SPMeta2.Definitions
 
         public override string ToString()
         {
-            return string.Format("Name:[{0}] Description:[{1}]", Name, Description);
+            return string.Format("Name:[{0}] Description:[{1}] Owner:[{2}]", Name, Description, Owner);
         }
 
         #endregion


### PR DESCRIPTION
I ran into a local issue with SecurityGroup on a customer environment and Owner property wasn't logged, so I changed this because I think Owner is a very crucial property so it wouldn't hurt to see this property in log